### PR TITLE
Resuse normal sprite if selected and disabled are not provided

### DIFF
--- a/cocos2d/menu_nodes/CCMenuItemImage.cs
+++ b/cocos2d/menu_nodes/CCMenuItemImage.cs
@@ -8,13 +8,23 @@ namespace Cocos2D
         {
         }
 
+        public CCMenuItemImage(string normalImage)
+            : this(normalImage, normalImage, normalImage, null)
+        {
+        }
+
         public CCMenuItemImage(string normalImage, string selectedImage)
-            :this(normalImage, selectedImage, null, null)
+            :this(normalImage, selectedImage, normalImage, null)
         {
         }
 
         public CCMenuItemImage(string normalImage, string selectedImage, Action<CCMenuItem> selector)
-            :this(normalImage, selectedImage, null, selector)
+            :this(normalImage, selectedImage, normalImage, selector)
+        {
+        }
+
+        public CCMenuItemImage(string normalImage, string selectedImage, string disabledImage)
+            : this(normalImage, selectedImage, disabledImage, null)
         {
         }
 
@@ -36,11 +46,6 @@ namespace Cocos2D
             {
                 DisabledImage = new CCSprite(disabledImage);
             }
-        }
-
-        public CCMenuItemImage(string normalImage, string selectedImage, string disabledImage)
-            : this(normalImage, selectedImage, disabledImage, null)
-        {
         }
 
         public void SetNormalSpriteFrame(CCSpriteFrame frame)

--- a/cocos2d/menu_nodes/CCMenuItemSprite.cs
+++ b/cocos2d/menu_nodes/CCMenuItemSprite.cs
@@ -167,23 +167,28 @@ namespace Cocos2D
         {
         }
 
+        public CCMenuItemSprite(string normalSprite, Action<CCMenuItem> selector)
+            : this(new CCSprite(normalSprite), new CCSprite(normalSprite), new CCSprite(normalSprite), selector)
+        {
+        }
+
         public CCMenuItemSprite(string normalSprite, string selectedSprite, Action<CCMenuItem> selector)
-            :this(new CCSprite(normalSprite), new CCSprite(selectedSprite), null, selector)
+            :this(new CCSprite(normalSprite), new CCSprite(selectedSprite), new CCSprite(normalSprite), selector)
         {
         }
 
         public CCMenuItemSprite(CCTexture2D normalSprite, CCTexture2D selectedSprite, Action<CCMenuItem> selector)
-            : this(new CCSprite(normalSprite), new CCSprite(selectedSprite), null, selector)
+            : this(new CCSprite(normalSprite), new CCSprite(selectedSprite), new CCSprite(normalSprite), selector)
         {
         }
 
         public CCMenuItemSprite(CCNode normalSprite, CCNode selectedSprite)
-            :this(normalSprite, selectedSprite, null, null)
+            :this(normalSprite, selectedSprite, normalSprite, null)
         {
         }
 
 		public CCMenuItemSprite(CCNode normalSprite, CCNode selectedSprite, Action<CCMenuItem> selector)
-            :this(normalSprite, selectedSprite, null, selector)
+            :this(normalSprite, selectedSprite, normalSprite, selector)
         {
         }
 


### PR DESCRIPTION
Resolves #150 

This change will also apply to CCMenuItemImage.

If there are no images/sprites specified for selected or disabled states, then the normal image/sprite will be used in its place. This is meant to provide overall stability and improvement over the experience/expectation of CCMenuItemImage/Sprite.

This change can only be ignored if you use the full constructor for either CCMenuItemImage or CCMenuItemSprite to explicitly opt out.

Example:
`public CCMenuItemSprite(CCNode normalSprite, CCNode selectedSprite, CCNode disabledSprite, Action<CCMenuItem> selector)`

You then set null for whichever states you don't want to set one for.