### PR TITLE
fixes and streamline for removefromparent calls

### DIFF
--- a/Tests/cocos2d-mono.Tests/ActionsTest/ActionsTest.cs
+++ b/Tests/cocos2d-mono.Tests/ActionsTest/ActionsTest.cs
@@ -604,9 +604,9 @@ namespace tests
         {
             base.OnEnter();
 
-            m_tamara.RemoveFromParentAndCleanup(true);
-            m_grossini.RemoveFromParentAndCleanup(true);
-            m_kathia.RemoveFromParentAndCleanup(true);
+            m_tamara.RemoveFromParent();
+            m_grossini.RemoveFromParent();
+            m_kathia.RemoveFromParent();
 
             var s = CCDirector.SharedDirector.WinSize;
 
@@ -655,9 +655,9 @@ namespace tests
 
             base.OnEnter();
 
-            m_tamara.RemoveFromParentAndCleanup(true);
-            m_grossini.RemoveFromParentAndCleanup(true);
-            m_kathia.RemoveFromParentAndCleanup(true);
+            m_tamara.RemoveFromParent();
+            m_grossini.RemoveFromParent();
+            m_kathia.RemoveFromParent();
 
 			// Get window size so that we can center the box layer
 			var winSize = CCDirector.SharedDirector.WinSize;
@@ -1082,7 +1082,7 @@ namespace tests
 
             var action = new CCSequence(
                 new CCMoveBy (2.0f, new CCPoint(200, 0)),
-                new CCCallFuncND(removeFromParentAndCleanup, true)
+                new CCCallFuncND(removeFromParent, true)
                 );
 
             m_grossini.RunAction(action);
@@ -1098,10 +1098,10 @@ namespace tests
             return "CallFuncND + removeFromParentAndCleanup. Grossini dissapears in 2s";
         }
 
-        private void removeFromParentAndCleanup(CCNode pSender, object data)
+        private void removeFromParent(CCNode pSender, object data)
         {
             var bCleanUp = (bool) data;
-            m_grossini.RemoveFromParentAndCleanup(bCleanUp);
+            m_grossini.RemoveFromParent(bCleanUp);
         }
     }
 

--- a/Tests/cocos2d-mono.Tests/LabelTest/LabelTTFTest.cs
+++ b/Tests/cocos2d-mono.Tests/LabelTest/LabelTTFTest.cs
@@ -53,7 +53,7 @@ namespace tests
 
             if (m_plabel != null)
             {
-                m_plabel.RemoveFromParentAndCleanup(true);
+                m_plabel.RemoveFromParent();
             }
 
             m_plabel = new CCLabelTTF(getCurrentAlignment(), "Marker Felt", 32,

--- a/Tests/cocos2d-mono.Tests/NodeTest/StressTest2.cs
+++ b/Tests/cocos2d-mono.Tests/NodeTest/StressTest2.cs
@@ -38,7 +38,7 @@ namespace tests
         {
             Unschedule((shouldNotLeak));
             var sublayer = (CCLayer) GetChildByTag(CocosNodeTestStaticLibrary.kTagSprite1);
-            sublayer.RemoveAllChildrenWithCleanup(true);
+            sublayer.RemoveAllChildren();
         }
 
         public override string title()

--- a/Tests/cocos2d-mono.Tests/ParticleTest/ParticleTest.cs
+++ b/Tests/cocos2d-mono.Tests/ParticleTest/ParticleTest.cs
@@ -1456,7 +1456,7 @@ namespace tests
         private void switchRender(float dt)
         {
             bool usingBatch = (m_emitter.BatchNode != null);
-            m_emitter.RemoveFromParentAndCleanup(false);
+            m_emitter.RemoveFromParent();
 
             CCNode newParent = (usingBatch ? m_pParent2 : m_pParent1);
             newParent.AddChild(m_emitter);

--- a/Tests/cocos2d-mono.Tests/SpriteTest/SpriteHybrid.cs
+++ b/Tests/cocos2d-mono.Tests/SpriteTest/SpriteHybrid.cs
@@ -95,7 +95,7 @@ namespace tests
             }
 
             int i = 0;
-            p1.RemoveAllChildrenWithCleanup(false);
+            p1.RemoveAllChildren(false);
 
             foreach (var item in retArray)
             {

--- a/cocos2d/actions/action_instants/CCRemoveSelf.cs
+++ b/cocos2d/actions/action_instants/CCRemoveSelf.cs
@@ -45,7 +45,7 @@ namespace Cocos2D
 
         public override void Update(float time)
         {
-            m_pTarget.RemoveFromParentAndCleanup(m_bIsNeedCleanUp);
+            m_pTarget.RemoveFromParent(m_bIsNeedCleanUp);
         }
 
         public override CCFiniteTimeAction Reverse()

--- a/cocos2d/base_nodes/CCNode.cs
+++ b/cocos2d/base_nodes/CCNode.cs
@@ -1023,12 +1023,7 @@ namespace Cocos2D
 
         #region RemoveChild
 
-        public void RemoveFromParent()
-        {
-            RemoveFromParentAndCleanup(true);
-        }
-
-        public void RemoveFromParentAndCleanup(bool cleanup)
+        public void RemoveFromParent(bool cleanup = true)
         {
             if (m_pParent != null)
             {
@@ -1036,12 +1031,7 @@ namespace Cocos2D
             }
         }
 
-        public void RemoveChild(CCNode child)
-        {
-            RemoveChild(child, true);
-        }
-
-        public virtual void RemoveChild(CCNode child, bool cleanup)
+        public virtual void RemoveChild(CCNode child, bool cleanup = true)
         {
             // explicit nil handling
             if (m_pChildren == null || child == null)
@@ -1097,12 +1087,7 @@ namespace Cocos2D
             }
         }
 
-        public virtual void RemoveAllChildren()
-        {
-            RemoveAllChildrenWithCleanup(true);
-        }
-
-        public virtual void RemoveAllChildrenWithCleanup(bool cleanup)
+        public virtual void RemoveAllChildren(bool cleanup = true)
         {
             // not using detachChild improves speed here
             if (m_pChildren != null && m_pChildren.Count > 0)
@@ -1133,8 +1118,6 @@ namespace Cocos2D
 
                     // set parent nil at the end
                     node.Parent = null;
-
-                    node.Dispose();
                 }
 
                 m_pChildren.Clear();
@@ -1177,8 +1160,6 @@ namespace Cocos2D
                     CCDirector.SharedDirector.TouchDispatcher.RearrangeAllHandlersUponTouch();
                 }
             }
-
-            child.Dispose();
         }
         #endregion
 

--- a/cocos2d/extentions/GUI/CCControlExtension/CCScale9Sprite.cs
+++ b/cocos2d/extentions/GUI/CCControlExtension/CCScale9Sprite.cs
@@ -248,10 +248,10 @@ namespace Cocos2D
             var color = Color;
 
             // Release old sprites
-            RemoveAllChildrenWithCleanup(true);
+            RemoveAllChildren();
 
             _scale9Image = batchnode;
-            _scale9Image.RemoveAllChildrenWithCleanup(true);
+            _scale9Image.RemoveAllChildren();
 
             _capInsets = capInsets;
             _spriteFrameRotated = rotated;

--- a/cocos2d/extentions/GUI/CCScrollView/CCScrollView.cs
+++ b/cocos2d/extentions/GUI/CCScrollView/CCScrollView.cs
@@ -186,7 +186,7 @@ namespace Cocos2D
                     return;
                 }
 
-                RemoveAllChildrenWithCleanup(true);
+                RemoveAllChildren();
                 _container = value;
 
                 _container.IgnoreAnchorPointForPosition = false;

--- a/cocos2d/misc_nodes/CCParallaxScrollNode.cs
+++ b/cocos2d/misc_nodes/CCParallaxScrollNode.cs
@@ -102,12 +102,12 @@ namespace Cocos2D
                 m_Batch.RemoveChild(node, cleanup);
             }
         }
-        public override void RemoveAllChildrenWithCleanup(bool cleanup)
+        public override void RemoveAllChildren(bool cleanup = true)
         {
             m_ScrollOffsets.Clear();
             if (m_Batch != null)
             {
-                m_Batch.RemoveAllChildrenWithCleanup(cleanup);
+                m_Batch.RemoveAllChildren(cleanup);
             }
         }
         /// <summary>

--- a/cocos2d/particle_nodes/CCParticleBatchNode.cs
+++ b/cocos2d/particle_nodes/CCParticleBatchNode.cs
@@ -396,14 +396,14 @@ namespace Cocos2D
             RemoveChild(m_pChildren[index], doCleanup);
         }
 
-        public override void RemoveAllChildrenWithCleanup(bool doCleanup)
+        public override void RemoveAllChildren(bool doCleanup = true)
         {
             for (int i = 0; i < m_pChildren.count; i++)
             {
                 ((CCParticleSystem) m_pChildren.Elements[i]).BatchNode = null;
             }
 
-            base.RemoveAllChildrenWithCleanup(doCleanup);
+            base.RemoveAllChildren(doCleanup);
 
             TextureAtlas.RemoveAllQuads();
         }

--- a/cocos2d/sprite_nodes/CCSprite.cs
+++ b/cocos2d/sprite_nodes/CCSprite.cs
@@ -1043,7 +1043,7 @@ namespace Cocos2D
             base.RemoveChild(child, cleanup);
         }
 
-        public override void RemoveAllChildrenWithCleanup(bool cleanup)
+        public override void RemoveAllChildren(bool cleanup = true)
         {
             if (m_pobBatchNode != null)
             {
@@ -1055,7 +1055,7 @@ namespace Cocos2D
                 }
             }
 
-            base.RemoveAllChildrenWithCleanup(cleanup);
+            base.RemoveAllChildren(cleanup);
 
             m_bHasChildren = false;
         }

--- a/cocos2d/sprite_nodes/CCSpriteBatchNode.cs
+++ b/cocos2d/sprite_nodes/CCSpriteBatchNode.cs
@@ -199,7 +199,7 @@ namespace Cocos2D
             RemoveChild((m_pChildren[index]), doCleanup);
         }
 
-        public override void RemoveAllChildrenWithCleanup(bool cleanup)
+        public override void RemoveAllChildren(bool cleanup = true)
         {
             // Invalidate atlas index. issue #569
             // useSelfRender should be performed on all descendants. issue #1216
@@ -209,7 +209,7 @@ namespace Cocos2D
                 elements[i].BatchNode = null;
             }
 
-            base.RemoveAllChildrenWithCleanup(cleanup);
+            base.RemoveAllChildren(cleanup);
 
             m_pobDescendants.Clear();
             m_pobTextureAtlas.RemoveAllQuads();

--- a/cocos2d/tileMap_parallax_nodes/CCParallaxNode.cs
+++ b/cocos2d/tileMap_parallax_nodes/CCParallaxNode.cs
@@ -55,10 +55,10 @@ namespace Cocos2D
             base.RemoveChild(child, cleanup);
         }
 
-        public override void RemoveAllChildrenWithCleanup(bool cleanup)
+        public override void RemoveAllChildren(bool cleanup = true)
         {
             m_pParallaxArray.Clear();
-            base.RemoveAllChildrenWithCleanup(cleanup);
+            base.RemoveAllChildren(cleanup);
         }
 
         private CCPoint AbsolutePosition()


### PR DESCRIPTION
Closes #308 #307 

This PR introduces some changes around usages of `RemoveFromParent`, `RemoveChild` and `RemoveAllChildren`.

First `RemoveFromParentAndCleanup` and `RemoveAllChildrenWithCleanup` have been removed in favor of simply passing in a `cleanup` parameter, which is now `true` by default. This mirrors the same behavior as before but without needing to explicitly call `RemoveFromParentAndCleanup` and `RemoveAllChildrenWithCleanup`.

For example, `m_plabel.RemoveFromParentAndCleanup(true);` would now look like `m_plabel.RemoveFromParent();`.

You can see that this helps to streamline the usage and cleanup will always be performed unless explicitly necessary by passing in `false` e.g. `m_plabel.RemoveFromParent(false);`.

This also reduces any confusion on whether `RemoveFromParent` or `RemoveFromParentAndCleanup` should be called. It is simply just `RemoveFromParent` in every case and just specify if cleanup is needed.