### PR TITLE
Fix for character spacing issue on Japanese language on iOS by removi…

### DIFF
--- a/cocos2d/label_nodes/CCLabel.cs
+++ b/cocos2d/label_nodes/CCLabel.cs
@@ -342,22 +342,6 @@ namespace Cocos2D
                             xKern = (int)Math.Ceiling(info.A + info.B + info.C),
                             xAdvance = (int)Math.Ceiling(info.A + info.B + info.C) + m_FontSpacing
                         };
-#if IOS
-                        if (IsCJKCharacter(chars[i]))
-                        {
-                            var deviceName = UIDevice.CurrentDevice.Name;
-                            var languages = NSUserDefaults.StandardUserDefaults.ArrayForKey("AppleLanguages");
-                            if (deviceName.Contains("13") || languages.Contains(new NSString("ja")))
-                            {
-                                fontDef.xAdvance = (int)(((int)Math.Ceiling(info.A + info.B + info.C) + m_FontSpacing) *
-                                                         0.75f);
-                            }
-                            else
-                            {
-                                fontDef.yOffset -= 10;
-                            }
-                        }
-#endif
                         fontConfig.CharacterSet.Add(chars[i]);
                         fontConfig.m_pFontDefDictionary.Add(chars[i], fontDef);
                     }

--- a/cocos2d/label_nodes/CCLabelUtilities-CoreGraphics.cs
+++ b/cocos2d/label_nodes/CCLabelUtilities-CoreGraphics.cs
@@ -252,7 +252,6 @@ namespace Cocos2D
 			nfloat leading;
 			abc = new ABCFloat[1];
 			abc[0].abcfB = (float)line.GetTypographicBounds(out ascent, out descent, out leading);
-            abc [0].abcfB += (float)leading;
 		}
 
 		internal static CCSize MeasureString (string textg, CTFont font, CCRect rect)


### PR DESCRIPTION
Fix for characters spacing issue on Japanese language on iOS by removing "leading" value (which is supposed to be used for **vertical** spacing between lines of text) from calculating **horizontal** spacing between characters (advanceX). (see what "leading" means in sense of typography https://www.cyrilchandelier.com/understanding-fonts-and-uifont)