### PR TITLE
We want to add possibility to set atlas texture size with static meth…

### DIFF
--- a/cocos2d/base_nodes/CCNode.cs
+++ b/cocos2d/base_nodes/CCNode.cs
@@ -2317,8 +2317,9 @@ namespace Cocos2D
             if (Children != null && Children.Count > 0)
             {
                 CCNode[] elements = Children.Elements;
-                foreach (CCNode child in Children.Elements)
+                for (var index = 0; index < Children.Elements.Length; index++)
                 {
+                    var child = Children.Elements[index];
                     if (child != null)
                     {
                         if (!child.m_bCleaned)
@@ -2337,10 +2338,12 @@ namespace Cocos2D
             if (Children != null && Children.Count > 0)
             {
                 CCNode[] elements = Children.Elements;
-                foreach (CCNode child in Children.Elements)
+                for (var index = 0; index < Children.Elements.Length; index++)
                 {
+                    var child = Children.Elements[index];
                     child?.CleanUpParentsProperly();
                 }
+
                 Children.Clear(true);
             }
             Parent = null;

--- a/cocos2d/label_nodes/CCLabel.cs
+++ b/cocos2d/label_nodes/CCLabel.cs
@@ -31,6 +31,8 @@ namespace Cocos2D
         }
 
         public static CCTexture2D m_pTexture;
+        private static CCSize m_pAtlasTextureSize = new CCSize(0, 0);
+        
         protected static bool m_bTextureDirty = true;
 
         protected string m_FontName;
@@ -90,6 +92,14 @@ namespace Cocos2D
                 }
 
                 UpdateLabel();
+            }
+        }
+
+        public static void SetTTFAtlasTextureSize(float width, float height)
+        {
+            if (width > 0 && height > 0)
+            {
+                m_pAtlasTextureSize = new CCSize(width, height);
             }
         }
 
@@ -177,7 +187,11 @@ namespace Cocos2D
 
             if (m_pData == null || s_pConfigurations.Count == 0)
             {
-                if (fontSize >= 105)
+                if (m_pAtlasTextureSize.Width > 0 && m_pAtlasTextureSize.Height > 0)
+                {
+                    InitializeTTFAtlas((int)m_pAtlasTextureSize.Width, (int)m_pAtlasTextureSize.Height);
+                }
+                else if (fontSize >= 105)
                 {
                     InitializeTTFAtlas(2048, 2048);
                 }


### PR DESCRIPTION
…od of CCLabel independently of font size at the moment; in our project when atlas is instantiated with values more then 1024x1024 it still causes crashes for low-end android devices