### PR TITLE
update to monogame 3.8.4

### DIFF
--- a/Nuget Packages/Cocos2D.Android.nuspec
+++ b/Nuget Packages/Cocos2D.Android.nuspec
@@ -22,8 +22,8 @@
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
       <group targetFramework="net8.0-android34.0">
-        <dependency id="MonoGame.Content.Builder.Task" version="3.8.2.1105" />
-        <dependency id="MonoGame.Framework.Android" version="3.8.2.1105" />
+        <dependency id="MonoGame.Content.Builder.Task" version="3.8.4" />
+        <dependency id="MonoGame.Framework.Android" version="3.8.4" />
         <dependency id="SharpZipLib" version="1.4.2" />
         <dependency id="OpenTK" version="4.9.4" />
       </group>

--- a/Nuget Packages/Cocos2D.Core.Android.nuspec
+++ b/Nuget Packages/Cocos2D.Core.Android.nuspec
@@ -22,7 +22,7 @@
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
       <group targetFramework="net8.0-android34.0">
-        <dependency id="MonoGame.Framework.Android" version="3.8.2.1105" />
+        <dependency id="MonoGame.Framework.Android" version="3.8.4" />
         <dependency id="SharpZipLib" version="1.4.2" />
         <dependency id="OpenTK" version="4.9.4" />
       </group>

--- a/Nuget Packages/Cocos2D.Core.DesktopGL.nuspec
+++ b/Nuget Packages/Cocos2D.Core.DesktopGL.nuspec
@@ -21,7 +21,7 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.2.1105" />
+      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.4" />
       <dependency id="OpenTK" version="4.9.4" />
       <dependency id="SharpZipLib" version="1.3.3" />
       <dependency id="SkiaSharp" version="3.116.1" />

--- a/Nuget Packages/Cocos2D.Core.Linux.nuspec
+++ b/Nuget Packages/Cocos2D.Core.Linux.nuspec
@@ -21,7 +21,7 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.2.1105" />
+      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.4" />
       <dependency id="OpenTK" version="4.9.4" />
       <dependency id="SharpZipLib" version="1.3.3" />
       <dependency id="SkiaSharp" version="3.116.1" />

--- a/Nuget Packages/Cocos2D.Core.Windows.nuspec
+++ b/Nuget Packages/Cocos2D.Core.Windows.nuspec
@@ -23,7 +23,7 @@
     <dependencies>
      <group targetFramework="net8.0-windows7.0">
         <dependency id="BitMiracle.LibTiff.NET" version="2.4.639" exclude="Build,Analyzers" />
-        <dependency id="MonoGame.Framework.WindowsDX" version="3.8.2.1105" exclude="Build,Analyzers" />
+        <dependency id="MonoGame.Framework.WindowsDX" version="3.8.4" exclude="Build,Analyzers" />
         <dependency id="SharpZipLib" version="1.3.3" exclude="Build,Analyzers" />
         <dependency id="System.Drawing.Common" version="8.0.8" exclude="Build,Analyzers" />
       </group>

--- a/Nuget Packages/Cocos2D.Core.iOS.nuspec
+++ b/Nuget Packages/Cocos2D.Core.iOS.nuspec
@@ -21,7 +21,7 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Framework.iOS" version="3.8.2.1105" />
+      <dependency id="MonoGame.Framework.iOS" version="3.8.4" />
       <dependency id="SharpZipLib" version="1.4.2" />
       <dependency id="OpenTK" version="4.9.4" />
     </dependencies>

--- a/Nuget Packages/Cocos2D.Core.macOS.nuspec
+++ b/Nuget Packages/Cocos2D.Core.macOS.nuspec
@@ -21,7 +21,7 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.2.1105" />
+      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.4" />
       <dependency id="OpenTK" version="4.9.4" />
       <dependency id="SharpZipLib" version="1.3.3" />
       <dependency id="SkiaSharp" version="3.116.1" />

--- a/Nuget Packages/Cocos2D.DesktopGL.nuspec
+++ b/Nuget Packages/Cocos2D.DesktopGL.nuspec
@@ -21,8 +21,8 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Content.Builder.Task" version="3.8.2.1105" />
-      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.2.1105" />
+      <dependency id="MonoGame.Content.Builder.Task" version="3.8.4" />
+      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.4" />
       <dependency id="OpenTK" version="4.9.4" />
       <dependency id="SharpZipLib" version="1.3.3" />
       <dependency id="SkiaSharp" version="3.116.1" />

--- a/Nuget Packages/Cocos2D.Linux.nuspec
+++ b/Nuget Packages/Cocos2D.Linux.nuspec
@@ -21,8 +21,8 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Content.Builder.Task" version="3.8.2.1105" />
-      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.2.1105" />
+      <dependency id="MonoGame.Content.Builder.Task" version="3.8.4" />
+      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.4" />
       <dependency id="OpenTK" version="4.9.4" />
       <dependency id="SharpZipLib" version="1.3.3" />
       <dependency id="SkiaSharp" version="3.116.1" />

--- a/Nuget Packages/Cocos2D.Windows.nuspec
+++ b/Nuget Packages/Cocos2D.Windows.nuspec
@@ -23,8 +23,8 @@
     <dependencies>
      <group targetFramework="net8.0-windows7.0">
         <dependency id="BitMiracle.LibTiff.NET" version="2.4.639" exclude="Build,Analyzers" />
-        <dependency id="MonoGame.Content.Builder.Task" version="3.8.2.1105" exclude="Build,Analyzers" />
-        <dependency id="MonoGame.Framework.WindowsDX" version="3.8.2.1105" exclude="Build,Analyzers" />
+        <dependency id="MonoGame.Content.Builder.Task" version="3.8.4" exclude="Build,Analyzers" />
+        <dependency id="MonoGame.Framework.WindowsDX" version="3.8.4" exclude="Build,Analyzers" />
         <dependency id="SharpZipLib" version="1.3.3" exclude="Build,Analyzers" />
         <dependency id="System.Drawing.Common" version="8.0.8" exclude="Build,Analyzers" />
       </group>

--- a/Nuget Packages/Cocos2D.iOS.nuspec
+++ b/Nuget Packages/Cocos2D.iOS.nuspec
@@ -21,8 +21,8 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Content.Builder.Task" version="3.8.2.1105" />
-      <dependency id="MonoGame.Framework.iOS" version="3.8.2.1105" />
+      <dependency id="MonoGame.Content.Builder.Task" version="3.8.4" />
+      <dependency id="MonoGame.Framework.iOS" version="3.8.4" />
       <dependency id="SharpZipLib" version="1.4.2" />
       <dependency id="OpenTK" version="4.9.4" />
     </dependencies>

--- a/Nuget Packages/Cocos2D.macOS.nuspec
+++ b/Nuget Packages/Cocos2D.macOS.nuspec
@@ -21,8 +21,8 @@
     <copyright>Copyright © 2025 Cocos2D-Mono Team; Broken Walls Studios, LLC.</copyright>
     <tags>mono monogame cocos2d game</tags>
     <dependencies>
-      <dependency id="MonoGame.Content.Builder.Task" version="3.8.2.1105" />
-      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.2.1105" />
+      <dependency id="MonoGame.Content.Builder.Task" version="3.8.4" />
+      <dependency id="MonoGame.Framework.DesktopGL" version="3.8.4" />
       <dependency id="OpenTK" version="4.9.4" />
       <dependency id="SharpZipLib" version="1.3.3" />
       <dependency id="SkiaSharp" version="3.116.1" />

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Android/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Android/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Android/cocos2d-mono.Tests.Android.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Android/cocos2d-mono.Tests.Android.csproj
@@ -38,8 +38,8 @@
     <AndroidSupportedAbis />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.4" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\strings.xml" />

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Android/cocos2d-mono.Tests.Core.Android.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Android/cocos2d-mono.Tests.Core.Android.csproj
@@ -38,7 +38,7 @@
     <AndroidSupportedAbis />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.4" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\strings.xml" />

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
@@ -67,7 +67,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\animations\animations-2.plist">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Windows/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Windows/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Windows/cocos2d-mono.Tests.Core.Windows.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Windows/cocos2d-mono.Tests.Core.Windows.csproj
@@ -70,7 +70,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\animations\animations-2.plist">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.iOS/cocos2d-mono.Tests.Core.iOS.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.iOS/cocos2d-mono.Tests.Core.iOS.csproj
@@ -69,7 +69,7 @@
     </MonoGameContentReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.4" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
@@ -70,7 +70,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
 </Project>

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.DesktopGL.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.DesktopGL.csproj
@@ -66,8 +66,8 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Linux/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Linux/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Linux/cocos2d-mono.Tests.Linux.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Linux/cocos2d-mono.Tests.Linux.csproj
@@ -66,8 +66,8 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Windows/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Windows/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Windows/cocos2d-mono.Tests.Windows.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Windows/cocos2d-mono.Tests.Windows.csproj
@@ -72,7 +72,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.iOS/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.iOS/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.iOS/cocos2d-mono.Tests.iOS.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.iOS/cocos2d-mono.Tests.iOS.csproj
@@ -73,8 +73,8 @@
     </MonoGameContentReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.4" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.macOS/.config/dotnet-tools.json
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.macOS/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.macOS/cocos2d-mono.Tests.macOS.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.macOS/cocos2d-mono.Tests.macOS.csproj
@@ -66,8 +66,8 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/box2d/box2d.DesktopGL/box2d.DesktopGL.csproj
+++ b/box2d/box2d.DesktopGL/box2d.DesktopGL.csproj
@@ -55,7 +55,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Logos\logo-small.png">

--- a/box2d/box2d.iOS/box2d.iOS.csproj
+++ b/box2d/box2d.iOS/box2d.iOS.csproj
@@ -42,7 +42,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.4" />
   </ItemGroup>
   <Import Project="..\box2d.projitems" Label="Shared" />
 </Project>

--- a/cocos2d/cocos2d.Android/.config/dotnet-tools.json
+++ b/cocos2d/cocos2d.Android/.config/dotnet-tools.json
@@ -3,23 +3,23 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb"]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor"]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-linux"]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-windows"]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.4",
       "commands": ["mgcb-editor-mac"]
     }
   }

--- a/cocos2d/cocos2d.Android/cocos2d.Android.csproj
+++ b/cocos2d/cocos2d.Android/cocos2d.Android.csproj
@@ -54,8 +54,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>

--- a/cocos2d/cocos2d.Core.Android/cocos2d.Core.Android.csproj
+++ b/cocos2d/cocos2d.Core.Android/cocos2d.Core.Android.csproj
@@ -54,7 +54,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>

--- a/cocos2d/cocos2d.Core.DesktopGL/cocos2d.Core.DesktopGL.csproj
+++ b/cocos2d/cocos2d.Core.DesktopGL/cocos2d.Core.DesktopGL.csproj
@@ -66,8 +66,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="3.116.1" />

--- a/cocos2d/cocos2d.Core.Linux/cocos2d.Core.Linux.csproj
+++ b/cocos2d/cocos2d.Core.Linux/cocos2d.Core.Linux.csproj
@@ -55,8 +55,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="3.116.1" />

--- a/cocos2d/cocos2d.Core.Windows/cocos2d.Core.Windows.csproj
+++ b/cocos2d/cocos2d.Core.Windows/cocos2d.Core.Windows.csproj
@@ -58,7 +58,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.639" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
   </ItemGroup>

--- a/cocos2d/cocos2d.Core.iOS/cocos2d.Core.iOS.csproj
+++ b/cocos2d/cocos2d.Core.iOS/cocos2d.Core.iOS.csproj
@@ -55,7 +55,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>

--- a/cocos2d/cocos2d.Core.macOS/cocos2d.Core.macOS.csproj
+++ b/cocos2d/cocos2d.Core.macOS/cocos2d.Core.macOS.csproj
@@ -55,8 +55,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="3.116.1" />

--- a/cocos2d/cocos2d.DesktopGL/cocos2d.DesktopGL.csproj
+++ b/cocos2d/cocos2d.DesktopGL/cocos2d.DesktopGL.csproj
@@ -67,8 +67,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="3.116.1" />

--- a/cocos2d/cocos2d.Linux/cocos2d.Linux.csproj
+++ b/cocos2d/cocos2d.Linux/cocos2d.Linux.csproj
@@ -56,8 +56,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="3.116.1" />

--- a/cocos2d/cocos2d.Windows/cocos2d.Windows.csproj
+++ b/cocos2d/cocos2d.Windows/cocos2d.Windows.csproj
@@ -58,8 +58,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.639" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
   </ItemGroup>

--- a/cocos2d/cocos2d.iOS/cocos2d.iOS.csproj
+++ b/cocos2d/cocos2d.iOS/cocos2d.iOS.csproj
@@ -55,8 +55,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>

--- a/cocos2d/cocos2d.macOS/cocos2d.macOS.csproj
+++ b/cocos2d/cocos2d.macOS/cocos2d.macOS.csproj
@@ -56,8 +56,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SkiaSharp" Version="3.116.1" />

--- a/cocos2d/platform/CCAccelerometer.cs
+++ b/cocos2d/platform/CCAccelerometer.cs
@@ -10,7 +10,7 @@ namespace Cocos2D
     {
 #if !WINDOWS && !PSM && !XBOX && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
         // the accelerometer sensor on the device
-        private static Microsoft.Devices.Sensors.Accelerometer accelerometer = null;
+        private static MonoGame.Framework.Devices.Sensors.Accelerometer accelerometer = null;
 #endif
 
         private const float TG3_GRAVITY_EARTH = 9.80665f;
@@ -25,7 +25,7 @@ namespace Cocos2D
 #if !WINDOWS && !PSM && !XBOX && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
             try
             {
-                accelerometer = new Microsoft.Devices.Sensors.Accelerometer();
+                accelerometer = new MonoGame.Framework.Devices.Sensors.Accelerometer();
             }
             catch (Exception ex)
             {
@@ -51,7 +51,7 @@ namespace Cocos2D
 #if !WINDOWS && !PSM && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
                     try
                 {
-                    if (Microsoft.Devices.Sensors.Accelerometer.IsSupported)
+                    if (MonoGame.Framework.Devices.Sensors.Accelerometer.IsSupported)
                     {
                         accelerometer.CurrentValueChanged += accelerometer_CurrentValueChanged;
                         accelerometer.Start();
@@ -62,7 +62,7 @@ namespace Cocos2D
                         m_bActive = false;
                     }
                 }
-                catch (Microsoft.Devices.Sensors.AccelerometerFailedException)
+                catch (MonoGame.Framework.Devices.Sensors.AccelerometerFailedException)
                 {
                     m_bActive = false;
                 }
@@ -99,7 +99,7 @@ namespace Cocos2D
 
 
 #if !WINDOWS && !PSM && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
-        private void accelerometer_CurrentValueChanged(object sender, Microsoft.Devices.Sensors.SensorReadingEventArgs<Microsoft.Devices.Sensors.AccelerometerReading> e)
+        private void accelerometer_CurrentValueChanged(object sender, MonoGame.Framework.Devices.Sensors.SensorReadingEventArgs<MonoGame.Framework.Devices.Sensors.AccelerometerReading> e)
         {
 
             // We have to use reflection to get the Vector3 value out of Acceleration


### PR DESCRIPTION
This pull request updates all project and test dependencies on MonoGame and related tools from version 3.8.2.1105 to 3.8.4 across the entire codebase. The update affects all NuGet package specifications and test project files, ensuring consistency and compatibility with the latest MonoGame release.

Dependency version upgrades:

**Production NuGet packages:**
* Updated `MonoGame.Framework.*` and `MonoGame.Content.Builder.Task` dependencies to version 3.8.4 in all relevant `.nuspec` files for Android, DesktopGL, Linux, macOS, Windows, and iOS packages. [[1]](diffhunk://#diff-55c11837915120dadc56cabce0207753ff555ca919832a92fc304e4daadde944L25-R26) [[2]](diffhunk://#diff-78fb1f2e60e88e1b6505231c28336a04e33ecfb07f4b16a0ac082f1251c1f828L25-R25) [[3]](diffhunk://#diff-326b3b3f6f56a8dce494d3116d36602ed7028b2a02ff574e7dd6665ab7717e3bL24-R24) [[4]](diffhunk://#diff-baad56baf709cf7d67efeed85c3d598ba213a00f98977c69b060be3dc720a600L24-R24) [[5]](diffhunk://#diff-f8592d33c016cbf5da8c5a3a3772bcec7dd4490a9f06c602371886cffb5ad498L26-R26) [[6]](diffhunk://#diff-ee7eecee660719c17ff77f4a8c280049a1bfd6713982dc73b7ff15f03f3dbf94L24-R24) [[7]](diffhunk://#diff-3f5bdc3a4e33fda5631e66520ae6b32f759c25a049bf48a3dbf0b33b0721d9fbL24-R24) [[8]](diffhunk://#diff-d1734555a6bd47ecedc01ea583cebee7f17a895a46c6fc39c53ac2aa8e8e599cL24-R25) [[9]](diffhunk://#diff-ec93874be1955f9b511156013ea916a99b087e4ab52fdd90ed9c0eab6742e621L24-R25) [[10]](diffhunk://#diff-525f533b77c95b0dff1be9a6faeae6705b72ade9f4e537026ebaf1c13864f766L26-R27) [[11]](diffhunk://#diff-b6d0903639ecfa1c729505c5e13adf95e4fe38eef79754b9c24b80132147d401L24-R25) [[12]](diffhunk://#diff-f5b0e1fdfd1621cbb4dfaf23b947630591968659391a2ac609dc86e0278e7a39L24-R25)

**Test projects and tools:**
* Updated all `MonoGame.Framework.*` and `MonoGame.Content.Builder.Task` package references to version 3.8.4 in test `.csproj` files for Android, DesktopGL, WindowsDX, and iOS test projects. [[1]](diffhunk://#diff-73374eaa0ac6a326c2f18dabe25885deec22e2246d80a5c4fb52549faf4558eeL41-R42) [[2]](diffhunk://#diff-50dbd169af612e7f52501516f3078caebd3b9d53ce3a32434e0ea7a11e9bd8e1L41-R41) [[3]](diffhunk://#diff-a77ee688d0bebc81cd42e8dff2b4bb63790c1594845f440dba4ea7f22a4b5b76L70-R70) [[4]](diffhunk://#diff-aecebcbbca575deff17eae605e96b1b8f11b7dde8fca4fda3b1d214ebc6b5219L73-R73) [[5]](diffhunk://#diff-8e88ea5a4f2a8819bb0b02d8bd7ea209a1120f8f9bab40bc179c1f09081ebba9L72-R72)
* Updated all `dotnet-mgcb` and `dotnet-mgcb-editor*` tool versions to 3.8.4 in test `.config/dotnet-tools.json` files, ensuring test tooling matches the updated runtime dependencies.

These changes keep the project up-to-date with the latest MonoGame improvements and fixes, and help maintain compatibility across all supported platforms.