### PR TITLE
add size prop for ccnode

### DIFF
--- a/cocos2d/base_nodes/CCNode.cs
+++ b/cocos2d/base_nodes/CCNode.cs
@@ -811,8 +811,8 @@ namespace Cocos2D
             }
         }
 
-                /// <summary>
-        /// Returns the bounding box of this node in the coordinate system of its parent.
+        /// <summary>
+        /// Returns the bounding box size of this node in the coordinate system of its parent.
         /// </summary>
         public CCSize Size
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `Size` property on nodes to expose width and height directly, derived from the node's bounding box and reported in the parent coordinate system for easier layout and measurement. This provides a convenient, read-only accessor for node dimensions without requiring manual bounding-box calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->