### PR TITLE
add draw node retained

### DIFF
--- a/Tests/cocos2d-mono.Tests/DrawPrimitivesTest/DrawNodeRetainedTest.cs
+++ b/Tests/cocos2d-mono.Tests/DrawPrimitivesTest/DrawNodeRetainedTest.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using Cocos2D;
+
+namespace tests
+{
+    /// <summary>
+    /// Tests CCDrawNodeRetained: adding shapes, moving, recoloring, and removing
+    /// individual shapes without clearing the entire buffer.
+    /// </summary>
+    public class DrawNodeRetainedTest : BaseDrawNodeTest
+    {
+        private CCDrawNodeRetained _drawNode;
+        private CCShapeHandle _movingDot;
+        private CCShapeHandle _colorRect;
+        private CCShapeHandle _fadingCircle;
+        private CCLabelTTF _statusLabel;
+        private float _elapsed;
+        private int _colorPhase;
+
+        public override string title() { return "CCDrawNodeRetained"; }
+        public override string subtitle() { return "Shapes move/recolor without Clear()"; }
+
+        public override bool Init()
+        {
+            base.Init();
+
+            CCSize s = CCDirector.SharedDirector.WinSize;
+
+            _drawNode = new CCDrawNodeRetained();
+            AddChild(_drawNode, 10);
+
+            // Static shapes that never change
+            _drawNode.AddFilledCircle(new CCPoint(80, s.Height * 0.7f), 30f,
+                new CCColor4F(0.3f, 0.3f, 0.3f, 1f));
+            _drawNode.AddTriangle(
+                new CCPoint(160, s.Height * 0.6f),
+                new CCPoint(200, s.Height * 0.8f),
+                new CCPoint(240, s.Height * 0.6f),
+                new CCColor4F(0.5f, 0.5f, 0.5f, 1f));
+
+            // Moving dot — will be repositioned every frame
+            _movingDot = _drawNode.AddDot(new CCPoint(s.Width / 2, s.Height * 0.5f), 15f,
+                CCColor4F.Red);
+
+            // Color-cycling rectangle
+            _colorRect = _drawNode.AddRect(
+                new CCRect(s.Width * 0.6f, s.Height * 0.3f, 100, 60),
+                CCColor4F.Green);
+
+            // Fading circle
+            _fadingCircle = _drawNode.AddFilledCircle(
+                new CCPoint(s.Width * 0.8f, s.Height * 0.6f), 40f,
+                CCColor4F.Blue);
+
+            _statusLabel = new CCLabelTTF("Shapes: 5 | No Clear() calls", "arial", 14);
+            _statusLabel.Position = new CCPoint(s.Width / 2, 60);
+            AddChild(_statusLabel);
+
+            _elapsed = 0;
+            _colorPhase = 0;
+
+            Schedule(UpdateShapes);
+
+            return true;
+        }
+
+        private void UpdateShapes(float dt)
+        {
+            _elapsed += dt;
+            CCSize s = CCDirector.SharedDirector.WinSize;
+
+            // Move dot in a circle
+            float cx = s.Width / 2 + (float)Math.Cos(_elapsed * 2.0) * 120f;
+            float cy = s.Height * 0.5f + (float)Math.Sin(_elapsed * 2.0) * 80f;
+            _drawNode.SetShapePosition(_movingDot, new CCPoint(cx, cy));
+
+            // Cycle rectangle color every 0.5s
+            if ((int)(_elapsed * 2) != _colorPhase)
+            {
+                _colorPhase = (int)(_elapsed * 2);
+                switch (_colorPhase % 4)
+                {
+                    case 0: _drawNode.RecolorShape(_colorRect, CCColor4F.Red); break;
+                    case 1: _drawNode.RecolorShape(_colorRect, CCColor4F.Green); break;
+                    case 2: _drawNode.RecolorShape(_colorRect, CCColor4F.Blue); break;
+                    case 3: _drawNode.RecolorShape(_colorRect, CCColor4F.Yellow); break;
+                }
+            }
+
+            // Pulse circle opacity
+            byte opacity = (byte)(128 + (int)(127 * Math.Sin(_elapsed * 3.0)));
+            _drawNode.SetShapeOpacity(_fadingCircle, opacity);
+
+            _statusLabel.Text = string.Format("Shapes: {0} | Verts: {1} | No Clear()",
+                _drawNode.ShapeCount, _drawNode.VertexCount);
+        }
+    }
+
+    /// <summary>
+    /// Tests removing shapes from CCDrawNodeRetained and verifying
+    /// that remaining shapes stay correctly positioned.
+    /// </summary>
+    public class DrawNodeRetainedRemoveTest : BaseDrawNodeTest
+    {
+        private CCDrawNodeRetained _drawNode;
+        private List<CCShapeHandle> _shapes;
+        private CCLabelTTF _statusLabel;
+        private float _elapsed;
+        private float _nextRemoveTime;
+
+        public override string title() { return "CCDrawNodeRetained Remove"; }
+        public override string subtitle() { return "Shapes removed one-by-one every 1s"; }
+
+        public override bool Init()
+        {
+            base.Init();
+
+            CCSize s = CCDirector.SharedDirector.WinSize;
+
+            _drawNode = new CCDrawNodeRetained();
+            AddChild(_drawNode, 10);
+
+            _shapes = new List<CCShapeHandle>();
+
+            // Create a row of colored circles
+            for (int i = 0; i < 8; i++)
+            {
+                float x = 60 + i * (s.Width - 120) / 7f;
+                float hue = i / 8f;
+                var color = new CCColor4F(
+                    Math.Max(0, 1f - Math.Abs(hue - 0.0f) * 3f),
+                    Math.Max(0, 1f - Math.Abs(hue - 0.33f) * 3f),
+                    Math.Max(0, 1f - Math.Abs(hue - 0.66f) * 3f),
+                    1f);
+                var handle = _drawNode.AddFilledCircle(new CCPoint(x, s.Height * 0.5f), 25f, color);
+                _shapes.Add(handle);
+            }
+
+            _statusLabel = new CCLabelTTF("Shapes: 8", "arial", 16);
+            _statusLabel.Position = new CCPoint(s.Width / 2, 60);
+            AddChild(_statusLabel);
+
+            _elapsed = 0;
+            _nextRemoveTime = 1f;
+
+            Schedule(UpdateRemoval);
+            return true;
+        }
+
+        private void UpdateRemoval(float dt)
+        {
+            _elapsed += dt;
+
+            if (_elapsed >= _nextRemoveTime && _shapes.Count > 0)
+            {
+                // Remove from the middle to test index compaction
+                int idx = _shapes.Count / 2;
+                _drawNode.RemoveShape(_shapes[idx]);
+                _shapes.RemoveAt(idx);
+                _nextRemoveTime += 1f;
+            }
+
+            _statusLabel.Text = string.Format("Shapes: {0} | Verts: {1}",
+                _drawNode.ShapeCount, _drawNode.VertexCount);
+        }
+
+    }
+}

--- a/Tests/cocos2d-mono.Tests/DrawPrimitivesTest/DrawPrimitivesTestScene.cs
+++ b/Tests/cocos2d-mono.Tests/DrawPrimitivesTest/DrawPrimitivesTestScene.cs
@@ -9,7 +9,7 @@ namespace tests
     public class DrawPrimitivesTestScene : TestScene
     {
         private static int sceneIdx = -1;
-        private static int MAX_LAYER = 11;
+        private static int MAX_LAYER = 13;
 
         public override void runThisTest()
         {
@@ -44,6 +44,10 @@ namespace tests
                     return new DrawNodeDotCircleTest();
                 case 10:
                     return new DrawNodeColorConversionsTest();
+                case 11:
+                    return new DrawNodeRetainedTest();
+                case 12:
+                    return new DrawNodeRetainedRemoveTest();
             }
             return null;
         }

--- a/Tests/cocos2d-mono.Tests/UtilitiesTest/UtilitiesTest.cs
+++ b/Tests/cocos2d-mono.Tests/UtilitiesTest/UtilitiesTest.cs
@@ -390,17 +390,18 @@ namespace tests
             for (int i = 0; i < 3; i++)
             {
                 var node = CreateNode(new CCColor4B(255, 60, 60, 200), 18);
-                node.Position = new CCPoint(200 + i * 100, s.Height * 0.65f);
+                node.Position = new CCPoint(200 + i * 100, s.Height * 0.5f);
                 node.CollisionCategory = CAT_ENEMY;
                 node.CollisionCategoryMask = CAT_BULLET;
                 _enemies.Add(node);
             }
 
             // Friendlies: category=FRIENDLY, mask=0 (collide with nothing)
+            // Same Y lane as bullets so AABBs can overlap — filtering should prevent hits
             for (int i = 0; i < 3; i++)
             {
                 var node = CreateNode(new CCColor4B(60, 60, 255, 200), 18);
-                node.Position = new CCPoint(200 + i * 100, s.Height * 0.35f);
+                node.Position = new CCPoint(200 + i * 100, s.Height * 0.5f);
                 node.CollisionCategory = CAT_FRIENDLY;
                 node.CollisionCategoryMask = 0; // collide with nothing
                 _friendlies.Add(node);

--- a/Tests/cocos2d-mono.Tests/UtilitiesTest/UtilitiesTest.cs
+++ b/Tests/cocos2d-mono.Tests/UtilitiesTest/UtilitiesTest.cs
@@ -348,4 +348,203 @@ namespace tests
             draw.DrawRect(new CCRect(x, y, w * progress, h), fillColor);
         }
     }
+
+    /// <summary>
+    /// Tests collision category filtering: two groups where only specific
+    /// category/mask pairs collide. Green pairs collide, gray pairs are filtered out.
+    /// </summary>
+    public class CollisionFilterTest : BaseUtilitiesTest
+    {
+        private List<CCDrawNode> _bullets = new List<CCDrawNode>();
+        private List<CCDrawNode> _enemies = new List<CCDrawNode>();
+        private List<CCDrawNode> _friendlies = new List<CCDrawNode>();
+        private CCDrawNode _overlay;
+        private CCLabelTTF _statusLabel;
+
+        const uint CAT_BULLET = 1 << 0;
+        const uint CAT_ENEMY = 1 << 1;
+        const uint CAT_FRIENDLY = 1 << 2;
+
+        public override string title() { return "Collision Categories"; }
+        public override string subtitle() { return "Bullets hit enemies (green), skip friendlies (gray)"; }
+
+        public override bool Init()
+        {
+            base.Init();
+            CCSize s = CCDirector.SharedDirector.WinSize;
+
+            _overlay = new CCDrawNode();
+            AddChild(_overlay, 20);
+
+            // Bullets: category=BULLET, mask=ENEMY only
+            for (int i = 0; i < 3; i++)
+            {
+                var node = CreateNode(new CCColor4B(255, 255, 0, 200), 12);
+                node.Position = new CCPoint(100 + i * 80, s.Height * 0.5f);
+                node.CollisionCategory = CAT_BULLET;
+                node.CollisionCategoryMask = CAT_ENEMY; // only collide with enemies
+                _bullets.Add(node);
+            }
+
+            // Enemies: category=ENEMY, mask=BULLET
+            for (int i = 0; i < 3; i++)
+            {
+                var node = CreateNode(new CCColor4B(255, 60, 60, 200), 18);
+                node.Position = new CCPoint(200 + i * 100, s.Height * 0.65f);
+                node.CollisionCategory = CAT_ENEMY;
+                node.CollisionCategoryMask = CAT_BULLET;
+                _enemies.Add(node);
+            }
+
+            // Friendlies: category=FRIENDLY, mask=0 (collide with nothing)
+            for (int i = 0; i < 3; i++)
+            {
+                var node = CreateNode(new CCColor4B(60, 60, 255, 200), 18);
+                node.Position = new CCPoint(200 + i * 100, s.Height * 0.35f);
+                node.CollisionCategory = CAT_FRIENDLY;
+                node.CollisionCategoryMask = 0; // collide with nothing
+                _friendlies.Add(node);
+            }
+
+            _statusLabel = new CCLabelTTF("", "arial", 16);
+            _statusLabel.Position = new CCPoint(s.Width / 2, 60);
+            AddChild(_statusLabel, 100);
+
+            Schedule(UpdateTest);
+            return true;
+        }
+
+        private CCDrawNode CreateNode(CCColor4B color, float size)
+        {
+            var node = new CCDrawNode();
+            node.DrawRect(new CCRect(-size, -size, size * 2, size * 2), color);
+            node.ContentSize = new CCSize(size * 2, size * 2);
+            node.AnchorPoint = CCPoint.AnchorMiddle;
+            AddChild(node, 10);
+            return node;
+        }
+
+        private void UpdateTest(float dt)
+        {
+            _overlay.Clear();
+
+            // Move bullets slowly right
+            foreach (var b in _bullets)
+            {
+                var p = b.Position;
+                p.X += 40f * dt;
+                CCSize s = CCDirector.SharedDirector.WinSize;
+                if (p.X > s.Width - 30) p.X = 30;
+                b.Position = p;
+            }
+
+            int hitEnemy = 0;
+            int hitFriendly = 0;
+
+            // Filtered: bullets vs enemies (should collide)
+            CCCollision.CheckGroupCollisionsFiltered(_bullets, _enemies, 0.8f, (a, b) =>
+            {
+                hitEnemy++;
+                _overlay.DrawRect(b.BoundingBox, new CCColor4B(0, 255, 0, 150));
+            });
+
+            // Filtered: bullets vs friendlies (should NOT collide due to mask)
+            CCCollision.CheckGroupCollisionsFiltered(_bullets, _friendlies, 0.8f, (a, b) =>
+            {
+                hitFriendly++;
+                _overlay.DrawRect(b.BoundingBox, new CCColor4B(255, 0, 0, 150));
+            });
+
+            _statusLabel.Text = string.Format("Enemy hits: {0} | Friendly hits: {1} (should be 0)",
+                hitEnemy, hitFriendly);
+        }
+    }
+
+    /// <summary>
+    /// Tests CCEaseMath standalone easing functions visually.
+    /// Dots animate along curves using different easing functions.
+    /// </summary>
+    public class EasingMathTest : BaseUtilitiesTest
+    {
+        private CCDrawNode _drawNode;
+        private float _elapsed;
+
+        private static readonly string[] _names = {
+            "Linear", "QuadIn", "QuadOut", "CubicIn", "CubicOut",
+            "SineIn", "SineOut", "BounceOut", "ElasticOut", "BackOut"
+        };
+
+        public override string title() { return "CCEaseMath"; }
+        public override string subtitle() { return "Standalone easing curves"; }
+
+        public override bool Init()
+        {
+            base.Init();
+
+            CCSize s = CCDirector.SharedDirector.WinSize;
+
+            _drawNode = new CCDrawNode();
+            AddChild(_drawNode, 10);
+
+            // Draw labels
+            for (int i = 0; i < _names.Length; i++)
+            {
+                float y = s.Height - 70 - i * ((s.Height - 120) / _names.Length);
+                var label = new CCLabelTTF(_names[i], "arial", 12);
+                label.Position = new CCPoint(60, y);
+                label.AnchorPoint = new CCPoint(1f, 0.5f);
+                AddChild(label, 100);
+            }
+
+            _elapsed = 0;
+            Schedule(UpdateEasing);
+            return true;
+        }
+
+        private void UpdateEasing(float dt)
+        {
+            _elapsed += dt;
+            float t = (_elapsed % 2f) / 2f; // 0→1 over 2 seconds
+
+            CCSize s = CCDirector.SharedDirector.WinSize;
+            _drawNode.Clear();
+
+            float startX = 80;
+            float endX = s.Width - 40;
+            float range = endX - startX;
+
+            for (int i = 0; i < _names.Length; i++)
+            {
+                float y = s.Height - 70 - i * ((s.Height - 120) / _names.Length);
+                float eased = ApplyEasing(i, t);
+
+                // Draw track line
+                _drawNode.DrawSegment(new CCPoint(startX, y), new CCPoint(endX, y), 1f,
+                    new CCColor4F(0.3f, 0.3f, 0.3f, 0.5f));
+
+                // Draw dot at eased position
+                float x = startX + eased * range;
+                _drawNode.DrawFilledCircle(new CCPoint(x, y), 6f,
+                    new CCColor4F(1f, 0.8f, 0f, 1f));
+            }
+        }
+
+        private float ApplyEasing(int index, float t)
+        {
+            switch (index)
+            {
+                case 0: return CCEaseMath.Linear(t);
+                case 1: return CCEaseMath.QuadIn(t);
+                case 2: return CCEaseMath.QuadOut(t);
+                case 3: return CCEaseMath.CubicIn(t);
+                case 4: return CCEaseMath.CubicOut(t);
+                case 5: return CCEaseMath.SineIn(t);
+                case 6: return CCEaseMath.SineOut(t);
+                case 7: return CCEaseMath.BounceOut(t);
+                case 8: return CCEaseMath.ElasticOut(t);
+                case 9: return CCEaseMath.BackOut(t);
+                default: return t;
+            }
+        }
+    }
 }

--- a/Tests/cocos2d-mono.Tests/UtilitiesTest/UtilitiesTestScene.cs
+++ b/Tests/cocos2d-mono.Tests/UtilitiesTest/UtilitiesTestScene.cs
@@ -5,7 +5,7 @@ namespace tests
     public class UtilitiesTestScene : TestScene
     {
         private static int sceneIdx = -1;
-        private static int MAX_LAYER = 3;
+        private static int MAX_LAYER = 5;
 
         public override void runThisTest()
         {
@@ -21,6 +21,8 @@ namespace tests
                 case 0: return new ObjectPoolTest();
                 case 1: return new CollisionTest();
                 case 2: return new CooldownTimerTest();
+                case 3: return new CollisionFilterTest();
+                case 4: return new EasingMathTest();
             }
             return null;
         }

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.projitems
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.projitems
@@ -289,6 +289,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DrawPrimitivesTest\DrawPrimitivesTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawPrimitivesTest\DrawPrimitivesTestScene.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawPrimitivesTest\DrawNodeNewMethodsTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DrawPrimitivesTest\DrawNodeRetainedTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EffectsAdvancedTest\Effect1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EffectsAdvancedTest\Effect2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EffectsAdvancedTest\Effect3.cs" />

--- a/cocos2d/cocos2d.projitems
+++ b/cocos2d/cocos2d.projitems
@@ -266,6 +266,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)menu_nodes\CCMenuItemToggle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)misc_nodes\CCClippingNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)misc_nodes\CCDrawNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)misc_nodes\CCDrawNodeRetained.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)misc_nodes\CCLightning.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)misc_nodes\CCLightningStreak.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)misc_nodes\CCMotionStreak.cs" />

--- a/cocos2d/misc_nodes/CCDrawNodeRetained.cs
+++ b/cocos2d/misc_nodes/CCDrawNodeRetained.cs
@@ -25,7 +25,9 @@ namespace Cocos2D
 
     /// <summary>
     /// A retained-mode draw node where individual shapes can be added, moved,
-    /// recolored, or removed without clearing and rebuilding the entire buffer.
+    /// recolored, or removed independently. Shape modifications (move, recolor,
+    /// opacity) update vertices in-place. The draw buffer array is rebuilt from
+    /// the vertex list on the next Draw() call when any change occurs.
     ///
     /// Use this instead of CCDrawNode when you have many shapes and only a few
     /// change per frame. The immediate-mode Clear() + redraw pattern still works
@@ -34,8 +36,8 @@ namespace Cocos2D
     /// <code>
     /// var node = new CCDrawNodeRetained();
     /// var dot = node.AddDot(center, 10f, CCColor4F.Red);
-    /// // Later, move or recolor without full rebuild:
-    /// node.MoveShape(dot, newCenter);
+    /// // Later, move or recolor:
+    /// node.SetShapePosition(dot, newCenter);
     /// node.RecolorShape(dot, CCColor4F.Blue);
     /// node.RemoveShape(dot);
     /// </code>
@@ -48,6 +50,7 @@ namespace Cocos2D
         private List<CCShapeHandle> m_shapes;
         private CCBlendFunc m_blendFunc;
         private VertexPositionColor[] m_drawBuffer;
+        private int m_drawBufferCount;
         private bool m_dirty;
 
         public CCDrawNodeRetained()
@@ -258,6 +261,7 @@ namespace Cocos2D
         public void SetShapePosition(CCShapeHandle handle, CCPoint position)
         {
             ValidateHandle(handle);
+            if (handle.VertexCount == 0) return;
 
             // Compute current centroid
             float cx = 0, cy = 0;
@@ -317,9 +321,9 @@ namespace Cocos2D
 
         /// <summary>
         /// Removes a shape from the draw node. This compacts the vertex buffer
-        /// and invalidates all handles that were added after this shape.
+        /// and adjusts indices on all remaining handles so they stay valid.
         /// For best performance, remove shapes in reverse order of creation
-        /// or use Clear() when removing many shapes.
+        /// or use Clear() when removing many shapes at once.
         /// </summary>
         public void RemoveShape(CCShapeHandle handle)
         {
@@ -364,19 +368,27 @@ namespace Cocos2D
 
         public override void Draw()
         {
-            if (m_vertices.Count == 0) return;
+            int vertCount = m_vertices.Count;
+            if (vertCount == 0) return;
 
             if (m_dirty)
             {
                 m_dirty = false;
-                m_drawBuffer = m_vertices.ToArray();
+                m_drawBufferCount = vertCount;
+
+                // Reuse existing array if large enough, otherwise grow
+                if (m_drawBuffer == null || m_drawBuffer.Length < vertCount)
+                {
+                    m_drawBuffer = new VertexPositionColor[vertCount];
+                }
+                m_vertices.CopyTo(m_drawBuffer);
             }
 
-            if (m_drawBuffer != null && m_drawBuffer.Length >= 3)
+            if (m_drawBuffer != null && m_drawBufferCount >= 3)
             {
                 CCDrawManager.TextureEnabled = false;
                 CCDrawManager.BlendFunc(m_blendFunc);
-                CCDrawManager.DrawPrimitives(PrimitiveType.TriangleList, m_drawBuffer, 0, m_drawBuffer.Length / 3);
+                CCDrawManager.DrawPrimitives(PrimitiveType.TriangleList, m_drawBuffer, 0, m_drawBufferCount / 3);
             }
         }
 

--- a/cocos2d/misc_nodes/CCDrawNodeRetained.cs
+++ b/cocos2d/misc_nodes/CCDrawNodeRetained.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Cocos2D
+{
+    /// <summary>
+    /// Identifies a shape drawn in a CCDrawNodeRetained, allowing
+    /// individual shapes to be moved, recolored, or removed without
+    /// rebuilding the entire vertex buffer.
+    /// </summary>
+    public class CCShapeHandle
+    {
+        internal int StartIndex;
+        internal int VertexCount;
+        internal CCDrawNodeRetained Owner;
+        internal bool Active = true;
+
+        /// <summary>
+        /// Whether this shape is still active (not removed).
+        /// </summary>
+        public bool IsActive { get { return Active; } }
+    }
+
+    /// <summary>
+    /// A retained-mode draw node where individual shapes can be added, moved,
+    /// recolored, or removed without clearing and rebuilding the entire buffer.
+    ///
+    /// Use this instead of CCDrawNode when you have many shapes and only a few
+    /// change per frame. The immediate-mode Clear() + redraw pattern still works
+    /// if needed.
+    ///
+    /// <code>
+    /// var node = new CCDrawNodeRetained();
+    /// var dot = node.AddDot(center, 10f, CCColor4F.Red);
+    /// // Later, move or recolor without full rebuild:
+    /// node.MoveShape(dot, newCenter);
+    /// node.RecolorShape(dot, CCColor4F.Blue);
+    /// node.RemoveShape(dot);
+    /// </code>
+    /// </summary>
+    public class CCDrawNodeRetained : CCNode
+    {
+        const int DefaultBufferSize = 512;
+
+        private List<VertexPositionColor> m_vertices;
+        private List<CCShapeHandle> m_shapes;
+        private CCBlendFunc m_blendFunc;
+        private VertexPositionColor[] m_drawBuffer;
+        private bool m_dirty;
+
+        public CCDrawNodeRetained()
+        {
+            m_blendFunc = CCBlendFunc.AlphaBlend;
+            m_vertices = new List<VertexPositionColor>(DefaultBufferSize);
+            m_shapes = new List<CCShapeHandle>();
+            m_dirty = true;
+        }
+
+        public CCBlendFunc BlendFunc
+        {
+            get { return m_blendFunc; }
+            set { m_blendFunc = value; }
+        }
+
+        /// <summary>
+        /// Number of active shapes in this node.
+        /// </summary>
+        public int ShapeCount
+        {
+            get { return m_shapes.Count; }
+        }
+
+        /// <summary>
+        /// Total vertex count across all shapes.
+        /// </summary>
+        public int VertexCount
+        {
+            get { return m_vertices.Count; }
+        }
+
+        #region Add Shapes
+
+        /// <summary>
+        /// Adds a filled dot and returns a handle for later manipulation.
+        /// </summary>
+        public CCShapeHandle AddDot(CCPoint pos, float radius, CCColor4F color)
+        {
+            if (radius >= 4f)
+            {
+                return AddFilledCircle(pos, radius, color);
+            }
+
+            int start = m_vertices.Count;
+            var cl = new Color(color.R, color.G, color.B, color.A);
+
+            var a = new VertexPositionColor(new Vector3(pos.X - radius, pos.Y - radius, 0), cl);
+            var b = new VertexPositionColor(new Vector3(pos.X - radius, pos.Y + radius, 0), cl);
+            var c = new VertexPositionColor(new Vector3(pos.X + radius, pos.Y + radius, 0), cl);
+            var d = new VertexPositionColor(new Vector3(pos.X + radius, pos.Y - radius, 0), cl);
+
+            m_vertices.Add(a);
+            m_vertices.Add(b);
+            m_vertices.Add(c);
+            m_vertices.Add(a);
+            m_vertices.Add(c);
+            m_vertices.Add(d);
+
+            return CreateHandle(start, 6);
+        }
+
+        /// <summary>
+        /// Adds a filled circle and returns a handle.
+        /// </summary>
+        public CCShapeHandle AddFilledCircle(CCPoint center, float radius, CCColor4F color, int segments = 32)
+        {
+            if (segments < 3) segments = 3;
+
+            int start = m_vertices.Count;
+            var cl = new Color(color.R, color.G, color.B, color.A);
+            var centerVertex = new VertexPositionColor(new Vector3(center.X, center.Y, 0), cl);
+            float increment = MathHelper.TwoPi / segments;
+
+            for (int i = 0; i < segments; i++)
+            {
+                float angle1 = i * increment;
+                float angle2 = (i + 1) * increment;
+
+                var v1 = new VertexPositionColor(
+                    new Vector3(center.X + (float)Math.Cos(angle1) * radius,
+                                center.Y + (float)Math.Sin(angle1) * radius, 0), cl);
+                var v2 = new VertexPositionColor(
+                    new Vector3(center.X + (float)Math.Cos(angle2) * radius,
+                                center.Y + (float)Math.Sin(angle2) * radius, 0), cl);
+
+                m_vertices.Add(centerVertex);
+                m_vertices.Add(v1);
+                m_vertices.Add(v2);
+            }
+
+            return CreateHandle(start, segments * 3);
+        }
+
+        /// <summary>
+        /// Adds a filled triangle and returns a handle.
+        /// </summary>
+        public CCShapeHandle AddTriangle(CCPoint a, CCPoint b, CCPoint c, CCColor4F color)
+        {
+            int start = m_vertices.Count;
+            var cl = new Color(color.R, color.G, color.B, color.A);
+
+            m_vertices.Add(new VertexPositionColor(new Vector3(a.X, a.Y, 0), cl));
+            m_vertices.Add(new VertexPositionColor(new Vector3(b.X, b.Y, 0), cl));
+            m_vertices.Add(new VertexPositionColor(new Vector3(c.X, c.Y, 0), cl));
+
+            return CreateHandle(start, 3);
+        }
+
+        /// <summary>
+        /// Adds a filled rectangle and returns a handle.
+        /// </summary>
+        public CCShapeHandle AddRect(CCRect rect, CCColor4F color)
+        {
+            int start = m_vertices.Count;
+            var cl = new Color(color.R, color.G, color.B, color.A);
+
+            float x1 = rect.MinX, y1 = rect.MinY;
+            float x2 = rect.MaxX, y2 = rect.MaxY;
+
+            var bl = new VertexPositionColor(new Vector3(x1, y1, 0), cl);
+            var br = new VertexPositionColor(new Vector3(x2, y1, 0), cl);
+            var tr = new VertexPositionColor(new Vector3(x2, y2, 0), cl);
+            var tl = new VertexPositionColor(new Vector3(x1, y2, 0), cl);
+
+            m_vertices.Add(bl);
+            m_vertices.Add(br);
+            m_vertices.Add(tr);
+            m_vertices.Add(bl);
+            m_vertices.Add(tr);
+            m_vertices.Add(tl);
+
+            return CreateHandle(start, 6);
+        }
+
+        /// <summary>
+        /// Adds a line segment and returns a handle.
+        /// </summary>
+        public CCShapeHandle AddSegment(CCPoint from, CCPoint to, float radius, CCColor4F color)
+        {
+            int start = m_vertices.Count;
+            var cl = new Color(color.R, color.G, color.B, color.A);
+
+            var a = from;
+            var b = to;
+            var n = CCPoint.Normalize(CCPoint.Perp(a - b));
+            var t = CCPoint.Perp(n);
+            var nw = n * radius;
+            var tw = t * radius;
+
+            var v0 = b - (nw + tw);
+            var v1 = b + (nw - tw);
+            var v2 = b - nw;
+            var v3 = b + nw;
+            var v4 = a - nw;
+            var v5 = a + nw;
+            var v6 = a - (nw - tw);
+            var v7 = a + (nw + tw);
+
+            m_vertices.Add(new VertexPositionColor(v0, cl));
+            m_vertices.Add(new VertexPositionColor(v1, cl));
+            m_vertices.Add(new VertexPositionColor(v2, cl));
+            m_vertices.Add(new VertexPositionColor(v3, cl));
+            m_vertices.Add(new VertexPositionColor(v1, cl));
+            m_vertices.Add(new VertexPositionColor(v2, cl));
+            m_vertices.Add(new VertexPositionColor(v3, cl));
+            m_vertices.Add(new VertexPositionColor(v4, cl));
+            m_vertices.Add(new VertexPositionColor(v2, cl));
+            m_vertices.Add(new VertexPositionColor(v3, cl));
+            m_vertices.Add(new VertexPositionColor(v4, cl));
+            m_vertices.Add(new VertexPositionColor(v5, cl));
+            m_vertices.Add(new VertexPositionColor(v6, cl));
+            m_vertices.Add(new VertexPositionColor(v4, cl));
+            m_vertices.Add(new VertexPositionColor(v5, cl));
+            m_vertices.Add(new VertexPositionColor(v6, cl));
+            m_vertices.Add(new VertexPositionColor(v7, cl));
+            m_vertices.Add(new VertexPositionColor(v5, cl));
+
+            return CreateHandle(start, 18);
+        }
+
+        #endregion
+
+        #region Manipulate Shapes
+
+        /// <summary>
+        /// Moves all vertices of a shape by the given offset.
+        /// </summary>
+        public void MoveShape(CCShapeHandle handle, CCPoint offset)
+        {
+            ValidateHandle(handle);
+            var off = new Vector3(offset.X, offset.Y, 0);
+
+            for (int i = handle.StartIndex; i < handle.StartIndex + handle.VertexCount; i++)
+            {
+                var v = m_vertices[i];
+                v.Position += off;
+                m_vertices[i] = v;
+            }
+
+            m_dirty = true;
+        }
+
+        /// <summary>
+        /// Sets the position of all vertices by translating the shape so its
+        /// centroid is at the given position.
+        /// </summary>
+        public void SetShapePosition(CCShapeHandle handle, CCPoint position)
+        {
+            ValidateHandle(handle);
+
+            // Compute current centroid
+            float cx = 0, cy = 0;
+            for (int i = handle.StartIndex; i < handle.StartIndex + handle.VertexCount; i++)
+            {
+                cx += m_vertices[i].Position.X;
+                cy += m_vertices[i].Position.Y;
+            }
+            cx /= handle.VertexCount;
+            cy /= handle.VertexCount;
+
+            var off = new Vector3(position.X - cx, position.Y - cy, 0);
+            for (int i = handle.StartIndex; i < handle.StartIndex + handle.VertexCount; i++)
+            {
+                var v = m_vertices[i];
+                v.Position += off;
+                m_vertices[i] = v;
+            }
+
+            m_dirty = true;
+        }
+
+        /// <summary>
+        /// Changes the color of all vertices in a shape.
+        /// </summary>
+        public void RecolorShape(CCShapeHandle handle, CCColor4F color)
+        {
+            ValidateHandle(handle);
+            var cl = new Color(color.R, color.G, color.B, color.A);
+
+            for (int i = handle.StartIndex; i < handle.StartIndex + handle.VertexCount; i++)
+            {
+                var v = m_vertices[i];
+                v.Color = cl;
+                m_vertices[i] = v;
+            }
+
+            m_dirty = true;
+        }
+
+        /// <summary>
+        /// Sets the opacity of all vertices in a shape.
+        /// </summary>
+        public void SetShapeOpacity(CCShapeHandle handle, byte opacity)
+        {
+            ValidateHandle(handle);
+
+            for (int i = handle.StartIndex; i < handle.StartIndex + handle.VertexCount; i++)
+            {
+                var v = m_vertices[i];
+                v.Color = new Color(v.Color.R, v.Color.G, v.Color.B, opacity);
+                m_vertices[i] = v;
+            }
+
+            m_dirty = true;
+        }
+
+        /// <summary>
+        /// Removes a shape from the draw node. This compacts the vertex buffer
+        /// and invalidates all handles that were added after this shape.
+        /// For best performance, remove shapes in reverse order of creation
+        /// or use Clear() when removing many shapes.
+        /// </summary>
+        public void RemoveShape(CCShapeHandle handle)
+        {
+            ValidateHandle(handle);
+
+            int start = handle.StartIndex;
+            int count = handle.VertexCount;
+
+            m_vertices.RemoveRange(start, count);
+
+            handle.Active = false;
+            m_shapes.Remove(handle);
+
+            // Update start indices for all shapes after the removed one
+            for (int i = 0; i < m_shapes.Count; i++)
+            {
+                if (m_shapes[i].StartIndex > start)
+                {
+                    m_shapes[i].StartIndex -= count;
+                }
+            }
+
+            m_dirty = true;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Clears all shapes and vertices.
+        /// </summary>
+        public void Clear()
+        {
+            m_vertices.Clear();
+            for (int i = 0; i < m_shapes.Count; i++)
+            {
+                m_shapes[i].Active = false;
+            }
+            m_shapes.Clear();
+            m_drawBuffer = null;
+            m_dirty = true;
+        }
+
+        public override void Draw()
+        {
+            if (m_vertices.Count == 0) return;
+
+            if (m_dirty)
+            {
+                m_dirty = false;
+                m_drawBuffer = m_vertices.ToArray();
+            }
+
+            if (m_drawBuffer != null && m_drawBuffer.Length >= 3)
+            {
+                CCDrawManager.TextureEnabled = false;
+                CCDrawManager.BlendFunc(m_blendFunc);
+                CCDrawManager.DrawPrimitives(PrimitiveType.TriangleList, m_drawBuffer, 0, m_drawBuffer.Length / 3);
+            }
+        }
+
+        private CCShapeHandle CreateHandle(int startIndex, int vertexCount)
+        {
+            var handle = new CCShapeHandle
+            {
+                StartIndex = startIndex,
+                VertexCount = vertexCount,
+                Owner = this,
+                Active = true
+            };
+            m_shapes.Add(handle);
+            m_dirty = true;
+            return handle;
+        }
+
+        private void ValidateHandle(CCShapeHandle handle)
+        {
+            if (handle == null)
+                throw new ArgumentNullException("handle");
+            if (!handle.Active)
+                throw new InvalidOperationException("Shape handle has been removed.");
+            if (handle.Owner != this)
+                throw new InvalidOperationException("Shape handle belongs to a different CCDrawNodeRetained.");
+        }
+    }
+}

--- a/cocos2d/misc_nodes/CCDrawNodeRetained.cs
+++ b/cocos2d/misc_nodes/CCDrawNodeRetained.cs
@@ -191,6 +191,13 @@ namespace Cocos2D
         /// </summary>
         public CCShapeHandle AddSegment(CCPoint from, CCPoint to, float radius, CCColor4F color)
         {
+            // Guard against zero-length segments which would produce NaN from Normalize
+            var delta = from - to;
+            if (delta.X * delta.X + delta.Y * delta.Y <= 1e-6f)
+            {
+                return AddDot(from, radius, color);
+            }
+
             int start = m_vertices.Count;
             var cl = new Color(color.R, color.G, color.B, color.A);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retained-mode shape drawing node with handle-based add/remove/manipulate API for dots, filled circles, triangles, rectangles, and segments; exposes blend mode, shape count, and vertex count.
* **Tests**
  * Added interactive tests demonstrating add/move/recolor/opacity/remove behaviors and automatic removal; added collision-filter and easing-math demo tests and updated test menus to include them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->