### PR TITLE
add font path guard

### DIFF
--- a/cocos2d/label_nodes/CCLabel-Android.cs
+++ b/cocos2d/label_nodes/CCLabel-Android.cs
@@ -39,21 +39,29 @@ namespace Cocos2D
             var ext = System.IO.Path.GetExtension(fontName);
             if (!String.IsNullOrEmpty(ext) && ext.ToLower() == ".ttf")
             {
-                // Get content root directory from CCApplication or CCContentManager (for CCGameView)
-                string contentRoot = CCApplication.SharedApplication != null
-                    ? CCApplication.SharedApplication.Game.Content.RootDirectory
-                    : (CCContentManager.SharedContentManager != null ? CCContentManager.SharedContentManager.RootDirectory : "Content");
-                var path = System.IO.Path.Combine(contentRoot, fontName);
-                var activity = Game.Activity;
-
-                try
+                if (System.IO.Path.IsPathRooted(fontName) || fontName.Contains(".."))
                 {
-                    var typeface = Typeface.CreateFromAsset(activity.Assets, path);
-                    _paint.SetTypeface(typeface);
-                }
-                catch (Exception)
-                {
+                    CCLog.Log("CCLabel-Android: Rejected font path '{0}' — must be relative with no '..' traversal", fontName);
                     _paint.SetTypeface(Typeface.Create(fontName, TypefaceStyle.Normal));
+                }
+                else
+                {
+                    // Get content root directory from CCApplication or CCContentManager (for CCGameView)
+                    string contentRoot = CCApplication.SharedApplication != null
+                        ? CCApplication.SharedApplication.Game.Content.RootDirectory
+                        : (CCContentManager.SharedContentManager != null ? CCContentManager.SharedContentManager.RootDirectory : "Content");
+                    var path = System.IO.Path.Combine(contentRoot, fontName);
+                    var activity = Game.Activity;
+
+                    try
+                    {
+                        var typeface = Typeface.CreateFromAsset(activity.Assets, path);
+                        _paint.SetTypeface(typeface);
+                    }
+                    catch (Exception)
+                    {
+                        _paint.SetTypeface(Typeface.Create(fontName, TypefaceStyle.Normal));
+                    }
                 }
             }
             else

--- a/cocos2d/platform/CCFontManager.cs
+++ b/cocos2d/platform/CCFontManager.cs
@@ -109,6 +109,8 @@ namespace Cocos2D
                 {
                     string appPath = AppDomain.CurrentDomain.BaseDirectory;
                     string contentRoot = Path.GetFullPath(Path.Combine(appPath, rootDir));
+                    if (!contentRoot.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                        contentRoot += Path.DirectorySeparatorChar;
                     string fullPath = Path.GetFullPath(Path.Combine(contentRoot, relativePath));
 
                     // Verify resolved path stays within the content root

--- a/cocos2d/platform/CCFontManager.cs
+++ b/cocos2d/platform/CCFontManager.cs
@@ -28,6 +28,11 @@ namespace Cocos2D
     {
         private static readonly HashSet<string> s_registeredTTFPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        private static readonly StringComparison s_pathComparison =
+            Environment.OSVersion.Platform == PlatformID.Win32NT
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
         /// <summary>
         /// Registers a TTF font file path for use with CCLabel.
         /// The path must be relative to the content root (e.g. "fonts/myfont.ttf").
@@ -114,7 +119,7 @@ namespace Cocos2D
                     string fullPath = Path.GetFullPath(Path.Combine(contentRoot, relativePath));
 
                     // Verify resolved path stays within the content root
-                    if (fullPath.StartsWith(contentRoot, StringComparison.OrdinalIgnoreCase))
+                    if (fullPath.StartsWith(contentRoot, s_pathComparison))
                     {
                         return fullPath;
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path normalization in font resolution to properly validate font file locations, addressing an edge case where directory path checking could behave incorrectly and ensuring font files are reliably validated against the content directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->