### PR TITLE
ROADMAP + first unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,25 @@
+name: unit-tests
+
+on:
+  push:
+    branches: [ dev, master ]
+  pull_request:
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Unit tests (DesktopGL / net9.0)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Test
+        run: dotnet test Tests/Cocos2DMono.UnitTests/Cocos2DMono.UnitTests.csproj -c Release

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
-
+          global-json-file: global.json
       - name: Test
         run: dotnet test Tests/Cocos2DMono.UnitTests/Cocos2DMono.UnitTests.csproj -c Release

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,39 @@
+# Cocos2D-Mono Roadmap
+
+Cocos2D-Mono is an actively maintained 2D game framework for .NET, built on MonoGame. This document outlines the direction of the project at a high level. Priorities and timing may shift, and feedback is welcome through the [issue tracker](https://github.com/Cocos2D-Mono/cocos2d-mono/issues).
+
+## Guiding principles
+
+- **Incremental and stable.** Improvements land in small, reviewable steps. We avoid large, disruptive rewrites.
+- **Compatibility first.** Where practical, public API changes go through `[Obsolete]` deprecation cycles. Breaking changes are signaled by a major version bump and documented with migration notes.
+- **Current platform.** Track current .NET and MonoGame releases.
+
+## Themes
+
+### Build & packaging
+Simplify the project and packaging layout — fewer, clearer NuGet packages with centralized, consistent dependency versions — so the framework is easier to consume and maintain. Any package change will ship with migration notes.
+
+### Quality & testing
+Grow automated test coverage (math primitives, actions, scheduling, serialization) and adopt code analyzers, so changes stay safe and regressions are caught early.
+
+### Modern C#
+Adopt current language features — nullable reference types for null-safety, up-to-date syntax, and value-type discipline for the math types — improving correctness and readability.
+
+### API & architecture *(longer-term, exploratory)*
+Evolve toward a more composable, testable design — composition over deep inheritance, optional dependency injection, and async content loading — while preserving familiar entry points. This work is exploratory and will be staged carefully.
+
+### Platforms
+Continue supporting desktop (Windows, macOS, Linux / DesktopGL), Android, and iOS. UWP / Xbox-UWP support is maintained separately in the [Cocos2D-Mono.UWP](https://github.com/Cocos2D-Mono/Cocos2D-Mono.UWP) repository.
+
+## Status at a glance
+
+| Theme | Status |
+|---|---|
+| Quality & testing | Next up |
+| Build & packaging | Planned |
+| Modern C# | Planned |
+| API & architecture | Exploratory |
+
+---
+
+*This roadmap is a living document, not a commitment to specific features or dates.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Continue supporting desktop (Windows, macOS, Linux / DesktopGL), Android, and iO
 ## Status at a glance
 
 | Theme | Status |
-|---|---|
+| --- | --- |
 | Quality & testing | Next up |
 | Build & packaging | Planned |
 | Modern C# | Planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,11 +28,12 @@ Continue supporting desktop (Windows, macOS, Linux / DesktopGL), Android, and iO
 ## Status at a glance
 
 | Theme | Status |
-| --- | --- |
+|---|---|
 | Quality & testing | Next up |
 | Build & packaging | Planned |
 | Modern C# | Planned |
 | API & architecture | Exploratory |
+| Platforms | Maintained |
 
 ---
 

--- a/Tests/Cocos2DMono.UnitTests/CCAffineTransformTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCAffineTransformTests.cs
@@ -1,0 +1,62 @@
+using Cocos2D;
+using Xunit;
+
+namespace Cocos2DMono.UnitTests;
+
+public class CCAffineTransformTests
+{
+    private const int Precision = 5;
+
+    [Fact]
+    public void Identity_LeavesPointUnchanged()
+    {
+        var p = new CCPoint(3f, 4f);
+        Assert.Equal(p, CCAffineTransform.Transform(p, CCAffineTransform.Identity));
+    }
+
+    [Fact]
+    public void Translate_OffsetsPoint()
+    {
+        var t = CCAffineTransform.Translate(CCAffineTransform.Identity, 5f, 7f);
+        Assert.Equal(new CCPoint(6f, 9f), CCAffineTransform.Transform(new CCPoint(1f, 2f), t));
+    }
+
+    [Fact]
+    public void Scale_ScalesPoint()
+    {
+        var t = CCAffineTransform.Scale(CCAffineTransform.Identity, 2f, 3f);
+        Assert.Equal(new CCPoint(8f, 15f), CCAffineTransform.Transform(new CCPoint(4f, 5f), t));
+    }
+
+    [Fact]
+    public void Concat_WithIdentity_IsNoOp()
+    {
+        var t = new CCAffineTransform(2f, 0f, 0f, 3f, 5f, 7f);
+        Assert.True(CCAffineTransform.Equal(t, CCAffineTransform.Concat(t, CCAffineTransform.Identity)));
+        Assert.True(CCAffineTransform.Equal(t, CCAffineTransform.Concat(CCAffineTransform.Identity, t)));
+    }
+
+    [Fact]
+    public void Invert_RoundTripsPoint()
+    {
+        // scale by (2,4) then translate by (3,5)
+        var t = CCAffineTransform.Translate(
+            CCAffineTransform.Scale(CCAffineTransform.Identity, 2f, 4f), 3f, 5f);
+        var p = new CCPoint(7f, 9f);
+
+        var forward = CCAffineTransform.Transform(p, t);
+        var back = CCAffineTransform.Transform(forward, CCAffineTransform.Invert(t));
+
+        Assert.Equal(p.X, back.X, Precision);
+        Assert.Equal(p.Y, back.Y, Precision);
+    }
+
+    [Fact]
+    public void Rotate90_MapsXAxisToYAxis()
+    {
+        var t = CCAffineTransform.Rotate(CCAffineTransform.Identity, (float)(Math.PI / 2.0));
+        var r = CCAffineTransform.Transform(new CCPoint(1f, 0f), t);
+        Assert.Equal(0f, r.X, Precision);
+        Assert.Equal(1f, r.Y, Precision);
+    }
+}

--- a/Tests/Cocos2DMono.UnitTests/CCPointTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCPointTests.cs
@@ -1,0 +1,88 @@
+using Cocos2D;
+using Xunit;
+
+namespace Cocos2DMono.UnitTests;
+
+public class CCPointTests
+{
+    [Fact]
+    public void Ctor_SetsXAndY()
+    {
+        var p = new CCPoint(3f, 4f);
+        Assert.Equal(3f, p.X);
+        Assert.Equal(4f, p.Y);
+    }
+
+    [Fact]
+    public void Zero_IsOrigin()
+    {
+        Assert.Equal(0f, CCPoint.Zero.X);
+        Assert.Equal(0f, CCPoint.Zero.Y);
+    }
+
+    [Fact]
+    public void Equality_OperatorsAndEquals()
+    {
+        var a = new CCPoint(1f, 2f);
+        var b = new CCPoint(1f, 2f);
+        var c = new CCPoint(2f, 1f);
+
+        Assert.True(a == b);
+        Assert.False(a == c);
+        Assert.True(a != c);
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void Addition_AddsComponents()
+    {
+        Assert.Equal(new CCPoint(4f, 6f), new CCPoint(1f, 2f) + new CCPoint(3f, 4f));
+    }
+
+    [Fact]
+    public void Subtraction_SubtractsComponents()
+    {
+        Assert.Equal(new CCPoint(4f, 5f), new CCPoint(5f, 7f) - new CCPoint(1f, 2f));
+    }
+
+    [Fact]
+    public void Negation_NegatesComponents()
+    {
+        Assert.Equal(new CCPoint(-3f, 4f), -new CCPoint(3f, -4f));
+    }
+
+    [Fact]
+    public void ScalarMultiply_And_Divide()
+    {
+        Assert.Equal(new CCPoint(2f, 4f), new CCPoint(1f, 2f) * 2f);
+        Assert.Equal(new CCPoint(1f, 2f), new CCPoint(2f, 4f) / 2f);
+    }
+
+    [Fact]
+    public void Distance_IsEuclidean()
+    {
+        Assert.Equal(5f, CCPoint.Distance(new CCPoint(0f, 0f), new CCPoint(3f, 4f)), 5);
+    }
+
+    [Fact]
+    public void Dot_Product()
+    {
+        // 1*3 + 2*4 = 11
+        Assert.Equal(11f, CCPoint.Dot(new CCPoint(1f, 2f), new CCPoint(3f, 4f)), 5);
+    }
+
+    [Fact]
+    public void Lerp_AtHalf_IsMidpoint()
+    {
+        Assert.Equal(new CCPoint(5f, 10f), CCPoint.Lerp(new CCPoint(0f, 0f), new CCPoint(10f, 20f), 0.5f));
+    }
+
+    [Fact]
+    public void Length_And_LengthSquared()
+    {
+        var p = new CCPoint(3f, 4f);
+        Assert.Equal(25f, p.LengthSquared, 5);
+        Assert.Equal(5f, p.Length, 5);
+    }
+}

--- a/Tests/Cocos2DMono.UnitTests/CCRectTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCRectTests.cs
@@ -1,0 +1,65 @@
+using Cocos2D;
+using Xunit;
+
+namespace Cocos2DMono.UnitTests;
+
+public class CCRectTests
+{
+    [Fact]
+    public void Edges_ComputedFromOriginAndSize()
+    {
+        var r = new CCRect(10f, 20f, 30f, 40f);
+        Assert.Equal(10f, r.MinX);
+        Assert.Equal(20f, r.MinY);
+        Assert.Equal(40f, r.MaxX); // 10 + 30
+        Assert.Equal(60f, r.MaxY); // 20 + 40
+        Assert.Equal(25f, r.MidX); // 10 + 30/2
+        Assert.Equal(40f, r.MidY); // 20 + 40/2
+    }
+
+    [Fact]
+    public void ContainsPoint_IsInclusiveOfEdges()
+    {
+        var r = new CCRect(0f, 0f, 10f, 10f);
+        Assert.True(r.ContainsPoint(new CCPoint(5f, 5f)));
+        Assert.True(r.ContainsPoint(0f, 0f));    // lower-left edge
+        Assert.True(r.ContainsPoint(10f, 10f));  // upper-right edge
+        Assert.False(r.ContainsPoint(new CCPoint(11f, 5f)));
+        Assert.False(r.ContainsPoint(new CCPoint(-1f, 5f)));
+    }
+
+    [Fact]
+    public void IntersectsRect_OverlapAndDisjoint()
+    {
+        var a = new CCRect(0f, 0f, 10f, 10f);
+        Assert.True(a.IntersectsRect(new CCRect(5f, 5f, 10f, 10f)));
+        Assert.False(a.IntersectsRect(new CCRect(100f, 100f, 5f, 5f)));
+    }
+
+    [Fact]
+    public void Union_EnclosesBothRects()
+    {
+        var u = new CCRect(0f, 0f, 10f, 10f).Union(new CCRect(20f, 20f, 10f, 10f));
+        Assert.Equal(0f, u.MinX);
+        Assert.Equal(0f, u.MinY);
+        Assert.Equal(30f, u.MaxX);
+        Assert.Equal(30f, u.MaxY);
+    }
+
+    [Fact]
+    public void Intersection_OfOverlappingRects()
+    {
+        var i = new CCRect(0f, 0f, 10f, 10f).Intersection(new CCRect(5f, 5f, 10f, 10f));
+        Assert.Equal(5f, i.MinX);
+        Assert.Equal(5f, i.MinY);
+        Assert.Equal(10f, i.MaxX);
+        Assert.Equal(10f, i.MaxY);
+    }
+
+    [Fact]
+    public void Intersection_OfDisjointRects_IsZero()
+    {
+        var i = new CCRect(0f, 0f, 10f, 10f).Intersection(new CCRect(100f, 100f, 5f, 5f));
+        Assert.True(i == CCRect.Zero);
+    }
+}

--- a/Tests/Cocos2DMono.UnitTests/CCSizeTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCSizeTests.cs
@@ -1,0 +1,42 @@
+using Cocos2D;
+using Xunit;
+
+namespace Cocos2DMono.UnitTests;
+
+public class CCSizeTests
+{
+    [Fact]
+    public void Ctor_SetsWidthAndHeight()
+    {
+        var s = new CCSize(640f, 480f);
+        Assert.Equal(640f, s.Width);
+        Assert.Equal(480f, s.Height);
+    }
+
+    [Fact]
+    public void Equality_OperatorsAndHashCode()
+    {
+        Assert.True(new CCSize(1f, 2f) == new CCSize(1f, 2f));
+        Assert.True(new CCSize(1f, 2f) != new CCSize(2f, 1f));
+        Assert.Equal(new CCSize(1f, 2f).GetHashCode(), new CCSize(1f, 2f).GetHashCode());
+    }
+
+    [Fact]
+    public void ScalarMultiply_And_Divide()
+    {
+        Assert.True(new CCSize(2f, 4f) == new CCSize(1f, 2f) * 2f);
+        Assert.True(new CCSize(1f, 2f) == new CCSize(2f, 4f) / 2f);
+    }
+
+    [Fact]
+    public void Center_IsHalfExtents()
+    {
+        Assert.Equal(new CCPoint(5f, 10f), new CCSize(10f, 20f).Center);
+    }
+
+    [Fact]
+    public void Zero_IsEmpty()
+    {
+        Assert.True(CCSize.Zero == new CCSize(0f, 0f));
+    }
+}

--- a/Tests/Cocos2DMono.UnitTests/Cocos2DMono.UnitTests.csproj
+++ b/Tests/Cocos2DMono.UnitTests/Cocos2DMono.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <!--
+    References the existing DesktopGL build for now. When Stage C lands the
+    consolidated csproj, this reference moves to it. The math types under test
+    (CCPoint/CCSize/CCRect/CCAffineTransform) are pure value types and need no
+    graphics device, so the suite runs headless.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\cocos2d\cocos2d.DesktopGL\cocos2d.DesktopGL.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What
Three additive, zero-risk changes that kick off the modernization effort:
1. **ROADMAP.md** — a high-level public roadmap (build & packaging, quality & testing, modern C#, longer-term API/architecture, platforms).
2. **Tests/Cocos2DMono.UnitTests** — a new xUnit project with the first **28** unit tests covering the pure-math value types: CCPoint, CCSize, CCRect, CCAffineTransform.
3. **.github/workflows/unit-tests.yml** — CI running the suite via `dotnet test` (DesktopGL / net9.0, Release) on windows-latest for pushes to dev/master and all PRs.

## Why
Establishes the first piece of a regression safety net — and the CI gate that enforces it — before any behavior-bearing changes, and publishes the roadmap to signal intent.

## Notes
- No production code touched — purely additive.
- Math types are pure value types, so the suite runs headless (no graphics device).
- Tests reference the existing `cocos2d.DesktopGL` build for now; that reference moves to the consolidated project during the later build consolidation.
- Verified locally (fresh Release build): 28 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project roadmap documenting direction, guiding principles, and focus areas.

* **Tests**
  * Added comprehensive unit test coverage for core math types (affine transforms, points, rectangles, sizes).
  * Established automated unit-test workflow that runs on pushes and pull requests to main branches (CI runs tests on Windows/.NET).
  * Test project now targets .NET 9.0 with updated test tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->