### PR TITLE
test: add color + CCVector2 coverage and CCSize/CCAffineTransform extras

### DIFF
--- a/Tests/Cocos2DMono.UnitTests/CCAffineTransformTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCAffineTransformTests.cs
@@ -59,4 +59,31 @@ public class CCAffineTransformTests
         Assert.Equal(0f, r.X, Precision);
         Assert.Equal(1f, r.Y, Precision);
     }
+
+    [Fact]
+    public void Concat_ScaleThenTranslate_TransformsPoint()
+    {
+        var scale = CCAffineTransform.Scale(CCAffineTransform.Identity, 2f, 2f);
+        var translate = CCAffineTransform.Translate(CCAffineTransform.Identity, 3f, 5f);
+
+        // Concat(scale, translate) applies the scale first, then the translate.
+        var combined = CCAffineTransform.Concat(scale, translate);
+
+        // (1,1) -> *2 -> (2,2) -> +(3,5) -> (5,7)
+        Assert.Equal(new CCPoint(5f, 7f), CCAffineTransform.Transform(new CCPoint(1f, 1f), combined));
+    }
+
+    [Fact]
+    public void Transform_Rect_ProducesScaledAabb()
+    {
+        var scale = CCAffineTransform.Scale(CCAffineTransform.Identity, 2f, 2f);
+
+        // Rect (1,1)-(3,3) scaled by 2 -> (2,2)-(6,6)
+        var r = scale.Transform(new CCRect(1f, 1f, 2f, 2f));
+
+        Assert.Equal(2f, r.MinX);
+        Assert.Equal(2f, r.MinY);
+        Assert.Equal(4f, r.Size.Width);
+        Assert.Equal(4f, r.Size.Height);
+    }
 }

--- a/Tests/Cocos2DMono.UnitTests/CCColorTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCColorTests.cs
@@ -1,0 +1,129 @@
+using Cocos2D;
+using Xunit;
+
+namespace Cocos2DMono.UnitTests;
+
+public class CCColorTests
+{
+    // --- CCColor3B ---
+
+    [Fact]
+    public void Color3B_Ctor_SetsComponents()
+    {
+        var c = new CCColor3B(10, 20, 30);
+        Assert.Equal(10, c.R);
+        Assert.Equal(20, c.G);
+        Assert.Equal(30, c.B);
+    }
+
+    [Fact]
+    public void Color3B_PredefinedValues()
+    {
+        Assert.Equal(new CCColor3B(255, 255, 255), CCColor3B.White);
+        Assert.Equal(new CCColor3B(255, 0, 0), CCColor3B.Red);
+        Assert.Equal(new CCColor3B(0, 255, 0), CCColor3B.Green);
+        Assert.Equal(new CCColor3B(0, 0, 255), CCColor3B.Blue);
+        Assert.Equal(new CCColor3B(255, 127, 0), CCColor3B.Orange);
+        Assert.Equal(new CCColor3B(166, 166, 166), CCColor3B.Gray);
+        Assert.Equal(new CCColor3B(0, 0, 0), CCColor3B.Black);
+    }
+
+    [Fact]
+    public void Color3B_AsColor4B_AddsOpaqueAlpha()
+    {
+        var c = new CCColor3B(10, 20, 30).AsColor4B();
+        Assert.Equal(10, c.R);
+        Assert.Equal(20, c.G);
+        Assert.Equal(30, c.B);
+        Assert.Equal(255, c.A);
+    }
+
+    [Fact]
+    public void Color3B_AsColor4B_WithExplicitAlpha()
+    {
+        Assert.Equal(128, new CCColor3B(10, 20, 30).AsColor4B(128).A);
+    }
+
+    // --- CCColor4B ---
+
+    [Fact]
+    public void Color4B_ByteCtor_DefaultsAlphaTo255()
+    {
+        Assert.Equal(255, new CCColor4B(1, 2, 3).A);
+    }
+
+    [Fact]
+    public void Color4B_PredefinedValues()
+    {
+        Assert.Equal(new CCColor4B(255, 255, 255, 255), CCColor4B.White);
+        Assert.Equal(new CCColor4B(0, 0, 0, 0), CCColor4B.Transparent);
+        Assert.Equal(new CCColor4B(255, 127, 0, 255), CCColor4B.Orange);
+    }
+
+    [Fact]
+    public void Color4B_FloatCtor_TruncatesNotNormalizes()
+    {
+        // Characterization: the float ctor casts straight to byte ((byte)inr) and treats
+        // inputs as already 0-255, NOT normalized 0-1. So 200.9f -> 200, and 0.9f -> 0.
+        var c = new CCColor4B(200.9f, 100f, 50f, 255f);
+        Assert.Equal(200, c.R);
+        Assert.Equal(100, c.G);
+        Assert.Equal(50, c.B);
+        Assert.Equal(255, c.A);
+
+        var sub = new CCColor4B(0.9f, 0.5f, 0.1f, 1f);
+        Assert.Equal(0, sub.R);
+        Assert.Equal(0, sub.G);
+        Assert.Equal(0, sub.B);
+        Assert.Equal(1, sub.A);
+    }
+
+    [Fact]
+    public void Color4B_EqualityOperators()
+    {
+        Assert.True(new CCColor4B(1, 2, 3, 4) == new CCColor4B(1, 2, 3, 4));
+        Assert.True(new CCColor4B(1, 2, 3, 4) != new CCColor4B(1, 2, 3, 5));
+    }
+
+    [Fact]
+    public void Color4B_ToString_And_Parse_RoundTrip()
+    {
+        var c = new CCColor4B(10, 20, 30, 40);
+        Assert.Equal("10,20,30,40", c.ToString());
+
+        var parsed = CCColor4B.Parse("10,20,30,40");
+        Assert.True(c == parsed);
+    }
+
+    [Fact]
+    public void Color4B_Lerp_Midpoint_IsByteTruncated()
+    {
+        // 50% between (0,0,0,0) and (100,200,50,255): A=127.5 truncates to 127.
+        var mid = CCColor4B.Lerp(new CCColor4B(0, 0, 0, 0), new CCColor4B(100, 200, 50, 255), 0.5f);
+        Assert.Equal(50, mid.R);
+        Assert.Equal(100, mid.G);
+        Assert.Equal(25, mid.B);
+        Assert.Equal(127, mid.A);
+    }
+
+    // --- Conversions ---
+
+    [Fact]
+    public void Implicit_Color3B_To_Color4B_AddsOpaqueAlpha()
+    {
+        CCColor4B c = new CCColor3B(10, 20, 30);
+        Assert.Equal(10, c.R);
+        Assert.Equal(20, c.G);
+        Assert.Equal(30, c.B);
+        Assert.Equal(255, c.A);
+    }
+
+    [Fact]
+    public void Implicit_Color4B_To_Color3B_DropsAlpha()
+    {
+        CCColor3B c = new CCColor4B(10, 20, 30, 40);
+        Assert.Equal(10, c.R);
+        Assert.Equal(20, c.G);
+        Assert.Equal(30, c.B);
+    }
+}

--- a/Tests/Cocos2DMono.UnitTests/CCSizeTests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCSizeTests.cs
@@ -39,4 +39,36 @@ public class CCSizeTests
     {
         Assert.True(CCSize.Zero == new CCSize(0f, 0f));
     }
+
+    [Fact]
+    public void Diagonal_IsHypotenuse()
+    {
+        Assert.Equal(5f, new CCSize(3f, 4f).Diagonal, 5);
+    }
+
+    [Fact]
+    public void Inverted_SwapsWidthAndHeight()
+    {
+        var s = new CCSize(3f, 4f).Inverted;
+        Assert.Equal(4f, s.Width);
+        Assert.Equal(3f, s.Height);
+    }
+
+    [Fact]
+    public void AsRect_IsOriginRectOfThisSize()
+    {
+        var r = new CCSize(10f, 20f).AsRect;
+        Assert.Equal(0f, r.MinX);
+        Assert.Equal(0f, r.MinY);
+        Assert.Equal(10f, r.Size.Width);
+        Assert.Equal(20f, r.Size.Height);
+    }
+
+    [Fact]
+    public void Clamp_CapsEachDimensionToMax()
+    {
+        var s = new CCSize(10f, 20f).Clamp(new CCSize(5f, 25f));
+        Assert.Equal(5f, s.Width);    // 10 capped to 5
+        Assert.Equal(20f, s.Height);  // 20 is under 25, unchanged
+    }
 }

--- a/Tests/Cocos2DMono.UnitTests/CCVector2Tests.cs
+++ b/Tests/Cocos2DMono.UnitTests/CCVector2Tests.cs
@@ -1,0 +1,92 @@
+using Cocos2D;
+using Xunit;
+
+namespace Cocos2DMono.UnitTests;
+
+public class CCVector2Tests
+{
+    private const int P = 5;
+
+    [Fact]
+    public void Ctor_SetsXY()
+    {
+        var v = new CCVector2(3f, 4f);
+        Assert.Equal(3f, v.X);
+        Assert.Equal(4f, v.Y);
+    }
+
+    [Fact]
+    public void StaticConstants()
+    {
+        Assert.Equal(new CCVector2(0f, 0f), CCVector2.Zero);
+        Assert.Equal(new CCVector2(1f, 1f), CCVector2.One);
+        Assert.Equal(new CCVector2(1f, 0f), CCVector2.UnitX);
+        Assert.Equal(new CCVector2(0f, 1f), CCVector2.UnitY);
+    }
+
+    [Fact]
+    public void Addition_Subtraction_Negation()
+    {
+        Assert.Equal(new CCVector2(4f, 6f), new CCVector2(1f, 2f) + new CCVector2(3f, 4f));
+        Assert.Equal(new CCVector2(2f, 2f), new CCVector2(5f, 7f) - new CCVector2(3f, 5f));
+        Assert.Equal(new CCVector2(-3f, 4f), -new CCVector2(3f, -4f));
+    }
+
+    [Fact]
+    public void ScalarMultiply_BothOrders_And_Divide()
+    {
+        Assert.Equal(new CCVector2(2f, 4f), new CCVector2(1f, 2f) * 2f);
+        Assert.Equal(new CCVector2(2f, 4f), 2f * new CCVector2(1f, 2f));
+        Assert.Equal(new CCVector2(1f, 2f), new CCVector2(2f, 4f) / 2f);
+    }
+
+    [Fact]
+    public void Dot_Product()
+    {
+        // 1*3 + 2*4 = 11
+        Assert.Equal(11f, CCVector2.Dot(new CCVector2(1f, 2f), new CCVector2(3f, 4f)), P);
+    }
+
+    [Fact]
+    public void Distance_And_DistanceSquared()
+    {
+        Assert.Equal(5f, CCVector2.Distance(new CCVector2(0f, 0f), new CCVector2(3f, 4f)), P);
+        Assert.Equal(25f, CCVector2.DistanceSquared(new CCVector2(0f, 0f), new CCVector2(3f, 4f)), P);
+    }
+
+    [Fact]
+    public void Length_And_LengthSquared()
+    {
+        var v = new CCVector2(3f, 4f);
+        Assert.Equal(5f, v.Length(), P);
+        Assert.Equal(25f, v.LengthSquared(), P);
+    }
+
+    [Fact]
+    public void Normalize_Static_ProducesUnitVector()
+    {
+        var n = CCVector2.Normalize(new CCVector2(3f, 4f));
+        Assert.Equal(0.6f, n.X, P);
+        Assert.Equal(0.8f, n.Y, P);
+        Assert.Equal(1f, n.Length(), P);
+    }
+
+    [Fact]
+    public void Lerp_AtHalf_IsMidpoint()
+    {
+        Assert.Equal(new CCVector2(5f, 10f), CCVector2.Lerp(new CCVector2(0f, 0f), new CCVector2(10f, 20f), 0.5f));
+    }
+
+    [Fact]
+    public void Equality_OperatorsAndEquals()
+    {
+        var a = new CCVector2(1f, 2f);
+        var b = new CCVector2(1f, 2f);
+        var c = new CCVector2(2f, 1f);
+
+        Assert.True(a == b);
+        Assert.True(a != c);
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+}


### PR DESCRIPTION
## What
Expands the value-type math coverage:
- **`CCColorTests`** — `CCColor3B`/`CCColor4B`: components, predefined colors, `AsColor4B`, equality, `ToString`/`Parse` round-trip, and the implicit conversions.
- **`CCVector2Tests`** — ctor, constants, operators, `Dot`, `Distance`, `Length`, `Normalize`, `Lerp`, equality.
- **`CCSizeTests`** (extended) — `Diagonal`, `Inverted`, `AsRect`, `Clamp`.
- **`CCAffineTransformTests`** (extended) — `Concat` composition and `Transform(CCRect)` AABB.

## Notes
- Additive, test-only; no production code touched. Pure value types — runs headless.
- Two behaviors pinned as **characterizations** (current behavior, flagged in case they're bugs): `CCColor4B(float,…)` truncates to byte rather than normalizing 0–1, and `CCColor4B.Lerp` byte-truncates.
- Suite total locally: **86 passed** (`dotnet test -c Release`).
