### PR TITLE
refactor: remove dead XBOX/WINDOWS_PHONE conditionals in box2d

### DIFF
--- a/box2d/Dynamics/b2World.cs
+++ b/box2d/Dynamics/b2World.cs
@@ -44,11 +44,7 @@ namespace Box2D.Dynamics
 
         public bool IsLocked
         {
-#if XBOX
-            get { return ((m_flags & b2WorldFlags.e_locked) == b2WorldFlags.e_locked); }
-#else
             get { return (m_flags & b2WorldFlags.e_locked) != 0; }
-#endif
         }
         private b2WorldFlags m_flags;
         public b2WorldFlags Flags

--- a/box2d/b2InternalClasses.cs
+++ b/box2d/b2InternalClasses.cs
@@ -49,24 +49,11 @@ namespace Box2D
             return new T[length];
         }
 
-#if WINDOWS_PHONE || XBOX
-        public static void Resize(ref T[] array, int length)
-        {
-            Resize(ref array, length, true);
-        }
-
-        public static void Resize(ref T[] array, int length, bool pow)
-        {
-            Free(array);
-            array = Create(length, pow);
-        }
-#else
         public static void Resize(ref T[] array, int length, bool pow = true)
         {
             Free(array);
             array = Create(length, pow);
         }
-#endif
         public static void Free(T[] array)
         {
             PoolEntry entry;
@@ -118,31 +105,6 @@ namespace Box2D
         {
             _unuseIndex = 0;
         }
-#if WINDOWS_PHONE || XBOX
-        public void Free()
-        {
-            Free(false);
-        }
-
-        public void Free(bool skipAssert)
-        {
-            if (index < _unuseIndex - 1)
-            {
-                var tmp = _created[--_unuseIndex];
-
-                tmp.index = index;
-                _created[index] = tmp;
-
-                index = _unuseIndex;
-                _created[_unuseIndex] = (T)this;
-            }
-            else
-            {
-                _unuseIndex--;
-            }
-        }
-    }
-#else
         public void Free(bool skipAssert = false)
         {
             if (index < _unuseIndex - 1)
@@ -161,7 +123,6 @@ namespace Box2D
             }
         }
     }
-#endif
 
     internal class b2IntStack : b2ReusedObject<b2IntStack>
     {


### PR DESCRIPTION
## What
First slice of the Stage B dead-conditional cleanup (Phase 2.1). Removes the dead
`#if XBOX` / `#if WINDOWS_PHONE || XBOX` branches in box2d, keeping the active `#else`:
- `b2World.IsLocked`
- `b2ReusedObject<T>` / `b2ArrayPool<T>` — the `Resize` and `Free` overloads

## Why
None of `XBOX`/`WINDOWS_PHONE` are defined in any build, so the `#else` branches are
what compiles today — pure dead-code removal, no behavior change.

## Notes
- 43 deletions, 0 additions; 111 unit tests green (`dotnet test -c Release`).
- Deliberately minimal first slice to validate the source → multi-platform build →
  test-net → CI flow before the larger cocos2d cleanups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified platform-specific code paths in physics engine internals for improved consistency across platforms.
  * Consolidated platform-specific method overloads into unified implementations with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->