### PR TITLE
refactor: remove dead WINDOWS_PHONE/XBOX/XBOX360 conditionals in cocos2d

### DIFF
--- a/cocos2d/extentions/Box2D/CCDraw.cs
+++ b/cocos2d/extentions/Box2D/CCDraw.cs
@@ -23,11 +23,7 @@ namespace Cocos2D
 
     public class CCBox2dDraw : b2Draw
     {
-#if XBOX || WINDOWS_PHONE
-        public const int CircleSegments = 16;
-#else
         public const int CircleSegments = 32;
-#endif
 
         private CCPrimitiveBatch _primitiveBatch;
         public Color TextColor = Color.White;

--- a/cocos2d/label_nodes/CCLabelBMFont.cs
+++ b/cocos2d/label_nodes/CCLabelBMFont.cs
@@ -749,11 +749,7 @@ namespace Cocos2D
                             multiline_string.Append('\n');
                         }
 
-#if XBOX || XBOX360
-                        last_word.Length = 0;
-#else
                         last_word.Clear();
-#endif
 
                         start_word = false;
                         start_line = false;
@@ -787,11 +783,7 @@ namespace Cocos2D
                     {
                         last_word.Append(character);
                         multiline_string.Append(last_word);
-#if XBOX || XBOX360
-                        last_word.Length = 0;
-#else
                         last_word.Clear();
-#endif
                         start_word = false;
                         startOfWord = -1;
                         i++;
@@ -847,11 +839,7 @@ namespace Cocos2D
                                     multiline_string.Append(last_word);
                                     multiline_string.Append('\n');
 
-#if XBOX || XBOX360
-                            last_word.Length = 0;
-#else
                                     last_word.Clear();
-#endif
 
                                     start_word = false;
                                     start_line = false;
@@ -894,11 +882,7 @@ namespace Cocos2D
                                 multiline_string.Append(last_word);
                                 multiline_string.Append('\n');
 
-#if XBOX || XBOX360
-                            last_word.Length = 0;
-#else
                                 last_word.Clear();
-#endif
 
                                 start_word = false;
                                 start_line = false;

--- a/cocos2d/particle_nodes/CCParticleSystem.cs
+++ b/cocos2d/particle_nodes/CCParticleSystem.cs
@@ -607,21 +607,7 @@ namespace Cocos2D
             if (zipInputStream.CanDecompressEntry) {
 
                 MemoryStream zipoutStream = new MemoryStream();
-#if XBOX
-                byte[] buf = new byte[4096];
-                int amt = -1;
-                while (true)
-                {
-                    amt = zipInputStream.Read(buf, 0, buf.Length);
-                    if (amt == -1)
-                    {
-                        break;
-                    }
-                    zipoutStream.Write(buf, 0, amt);
-                }
-#else
                 zipInputStream.CopyTo(zipoutStream);
-#endif
                 outputBytes = zipoutStream.ToArray();
             }
             else {
@@ -633,21 +619,7 @@ namespace Cocos2D
 
                 MemoryStream zipoutStream = new MemoryStream();
 
-#if XBOX
-                byte[] buf = new byte[4096];
-                int amt = -1;
-                while (true)
-                {
-                    amt = gzipInputStream.Read(buf, 0, buf.Length);
-                    if (amt == -1)
-                    {
-                        break;
-                    }
-                    zipoutStream.Write(buf, 0, amt);
-                }
-#else
                 gzipInputStream.CopyTo(zipoutStream);
-#endif
                 outputBytes = zipoutStream.ToArray();
                 }
                 catch (Exception exc)

--- a/cocos2d/platform/CCArrayPool.cs
+++ b/cocos2d/platform/CCArrayPool.cs
@@ -10,15 +10,7 @@ namespace Cocos2D
     {
         private static readonly Dictionary<int, List<object>> _unused = new Dictionary<int, List<object>>();
 
-#if WINDOWS_PHONE || XBOX
-        public static T[] Create(int length)
-        {
-            return (Create(length, true));
-        }
-        public static T[] Create(int length, bool pow)
-#else
         public static T[] Create(int length, bool pow = true)
-#endif
         {
             List<object> list;
 
@@ -45,15 +37,7 @@ namespace Cocos2D
             return new T[length];
         }
 
-#if WINDOWS_PHONE || XBOX
-        public static void Resize(ref T[] array, int length)
-        {
-            Resize(ref array, length, true);
-        }
-        public static void Resize(ref T[] array, int length, bool pow)
-#else
         public static void Resize(ref T[] array, int length, bool pow = true)
-#endif
         {
             Free(array);
             array = Create(length, pow);

--- a/cocos2d/support/zip_support/ZipUtils.cs
+++ b/cocos2d/support/zip_support/ZipUtils.cs
@@ -62,20 +62,7 @@ namespace Cocos2D
             try
             {
                 GZipStream gs = new GZipStream(new MemoryStream(parameterin, false)); // , CompressionMode.Decompress, false);
-#if XBOX
-                byte[] b = new byte[8096];
-                while (gs.CanRead)
-                {
-                    int amt = gs.Read(b, 0, b.Length);
-                    if (amt <= 0)
-                    {
-                        break;
-                    }
-                    ms.Write(b, 0, amt);
-                }
-#else
                 gs.CopyTo(ms);
-#endif
                 return ((int)ms.Length);
             }
             catch (Exception)


### PR DESCRIPTION
## What
Removes dead `#if WINDOWS_PHONE / XBOX / XBOX360` branches (keeping the active `#else`
paths — what compiles today, since none of those symbols are defined):
- `CCBox2dDraw.CircleSegments`
- `ZipUtils.InflateMemory` (manual loop → `Stream.CopyTo`)
- `ArrayPool<T>` — `Create`/`Resize` overloads collapse to the default-param versions
- `CCParticleSystem` zip/gzip decompress (manual loop → `CopyTo`, ×2)
- `CCLabelBMFont` — `last_word.Length = 0` → `.Clear()` (×4)

## Notes
- Pure dead-code removal, no behavior change; **111 tests green** (`dotnet test -c Release`).
- Verified no `WINDOWS_PHONE/XBOX/XBOX360/PSM/WP8/SILVERLIGHT` symbols remain in these files.
- Scope: the "delete dead branch" subset. Follow-ups handle the unwrap-always-true / `#elif`
  files and the `NETFX_CORE`/active-entangled files.
