### PR TITLE
refactor: simplify dead terms out of NETFX_CORE/WINDOWS conditionals

### DIFF
--- a/cocos2d/CCDirector.cs
+++ b/cocos2d/CCDirector.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
 using System.IO.IsolatedStorage;
 #endif
 using Microsoft.Xna.Framework;
@@ -54,7 +54,7 @@ namespace Cocos2D
         private bool m_NeedsInit = true;
         internal CCSize m_obWinSizeInPoints;
 		
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
         private CCAccelerometer m_pAccelerometer;
 #endif
 		private CCActionManager m_pActionManager;
@@ -89,7 +89,7 @@ namespace Cocos2D
         
         #region State Management
 		
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
         private string m_sStorageDirName = "cocos2dDirector";
         private string m_sSaveFileName = "SceneList.dat";
         private string m_sSceneSaveFileName = "Scene{0}.dat";
@@ -443,7 +443,7 @@ namespace Cocos2D
 			set { m_pKeyboardDispatcher = value; }
 		}
 
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
 		public CCAccelerometer Accelerometer
         {
             get { return m_pAccelerometer; }
@@ -575,7 +575,7 @@ namespace Cocos2D
 			m_pKeyboardDispatcher = new CCKeyboardDispatcher();
 
 			// Accelerometer
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
             m_pAccelerometer = new CCAccelerometer();
 #endif
 

--- a/cocos2d/cocoa/CCGeometry.cs
+++ b/cocos2d/cocoa/CCGeometry.cs
@@ -31,7 +31,7 @@ using Microsoft.Xna.Framework;
 
 namespace Cocos2D
 {
-#if !WINDOWS_PHONE && !XBOX && !NETFX_CORE
+#if !NETFX_CORE
     [Serializable, StructLayout(LayoutKind.Sequential), TypeConverter(typeof (CCPointConverter))]
 #endif
     public struct CCPoint
@@ -666,7 +666,7 @@ namespace Cocos2D
 
         public static CCPoint Parse(string s)
         {
-#if !WINDOWS_PHONE && !XBOX && !NETFX_CORE
+#if !NETFX_CORE
             return (CCPoint) TypeDescriptor.GetConverter(typeof (CCPoint)).ConvertFromString(s);
 #else
             return (CCPointConverter.CCPointFromString(s));
@@ -689,7 +689,7 @@ namespace Cocos2D
         }
     }
 
-#if !WINDOWS_PHONE && !XBOX && !NETFX_CORE
+#if !NETFX_CORE
     [Serializable, StructLayout(LayoutKind.Sequential), TypeConverter(typeof (CCSizeConverter))]
 #endif
     public struct CCSize
@@ -799,7 +799,7 @@ namespace Cocos2D
 
         public static CCSize Parse(string s)
         {
-#if !WINDOWS_PHONE && !XBOX && !NETFX_CORE
+#if !NETFX_CORE
             return (CCSize) TypeDescriptor.GetConverter(typeof (CCSize)).ConvertFromString(s);
 #else
             return (CCSizeConverter.CCSizeFromString(s));
@@ -827,7 +827,7 @@ namespace Cocos2D
         }
     }
 
-#if !WINDOWS_PHONE && !XBOX && !NETFX_CORE
+#if !NETFX_CORE
     [Serializable, StructLayout(LayoutKind.Sequential), TypeConverter(typeof (CCRectConverter))]
 #endif
     public struct CCRect
@@ -1093,7 +1093,7 @@ namespace Cocos2D
 
         public static CCRect Parse(string s)
         {
-#if !WINDOWS_PHONE && !XBOX && !NETFX_CORE
+#if !NETFX_CORE
             return (CCRect) TypeDescriptor.GetConverter(typeof (CCRect)).ConvertFromString(s);
 #else
             return (CCRectConverter.CCRectFromString(s));

--- a/cocos2d/platform/CCApplication.cs
+++ b/cocos2d/platform/CCApplication.cs
@@ -158,7 +158,7 @@ namespace Cocos2D
         {
             GameTime = gameTime;
 
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
             if (CCDirector.SharedDirector.Accelerometer != null)
             {
                 CCDirector.SharedDirector.Accelerometer.Update();

--- a/cocos2d/textures/CCTexture2D.cs
+++ b/cocos2d/textures/CCTexture2D.cs
@@ -247,7 +247,7 @@ namespace Cocos2D
                 switch (m_ePixelFormat)
                 {
                     case SurfaceFormat.Dxt1:
-#if !WINDOWS && !WINDOWS_PHONE && !XBOX
+#if !WINDOWS
                     case SurfaceFormat.Dxt1a:
                     case SurfaceFormat.RgbPvrtc2Bpp:
                     case SurfaceFormat.RgbaPvrtc2Bpp:
@@ -258,7 +258,7 @@ namespace Cocos2D
 
                     case SurfaceFormat.Dxt3:
                     case SurfaceFormat.Dxt5:
-#if !WINDOWS && !WINDOWS_PHONE && !XBOX
+#if !WINDOWS
                     case SurfaceFormat.RgbPvrtc4Bpp:
                     case SurfaceFormat.RgbaPvrtc4Bpp:
 #endif


### PR DESCRIPTION
## What
Trims the dead `WINDOWS_PHONE`/`XBOX`/`PSM` terms from mixed `#if` conditions while keeping
the gated `NETFX_CORE` guard and the active `WINDOWS` guard — behavior-identical, since the
dead symbols are never defined:
- `CCDirector` (×5) + `CCApplication` (×1): `!PSM && !NETFX_CORE` → `!NETFX_CORE`
- `CCGeometry` (×6): `!WINDOWS_PHONE && !XBOX && !NETFX_CORE` → `!NETFX_CORE`
- `CCTexture2D` (×2): `!WINDOWS && !WINDOWS_PHONE && !XBOX` → `!WINDOWS`

## Notes
- One-line condition edits only (no block restructuring); 111 tests green.
- Confirmed no `WINDOWS_PHONE/XBOX/PSM/...` remain in these files (`NETFX_CORE`/`WINDOWS` kept by design).
- First B3 sub-slice; the multi-symbol (`CCAccelerometer`, `CCDrawManager`) and structural (`CCLayer`, `CCUtils`, `CCTextFieldTTF`) files follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Expanded platform support for PSM, WINDOWS_PHONE, and XBOX builds by adjusting compilation conditions.
  * Improved texture format handling across different platform targets.
  * Enhanced state serialization and geometry conversion support across additional platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->