### PR TITLE
refactor: simplify/unwrap dead conditionals (CCAccelerometer, CCLayer…

### DIFF
--- a/cocos2d/layers_scenes_transitions_nodes/CCLayer.cs
+++ b/cocos2d/layers_scenes_transitions_nodes/CCLayer.cs
@@ -318,7 +318,7 @@ namespace Cocos2D
             // add this layer to concern the Accelerometer Sensor
             if (m_bIsAccelerometerEnabled)
             {
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
                 director.Accelerometer.SetDelegate(this);
 #endif
 			}
@@ -350,14 +350,10 @@ namespace Cocos2D
         public bool AccelerometerEnabled
         {
             get { 
-#if !PSM
-				return m_bIsAccelerometerEnabled; 
-#else
-				return(false);
-#endif
+				return m_bIsAccelerometerEnabled;
 			}
             set {
-#if !PSM &&!NETFX_CORE
+#if !NETFX_CORE
                 if (value != m_bIsAccelerometerEnabled)
                 {
                     m_bIsAccelerometerEnabled = value;

--- a/cocos2d/platform/CCAccelerometer.cs
+++ b/cocos2d/platform/CCAccelerometer.cs
@@ -8,7 +8,7 @@ namespace Cocos2D
 {
     public class CCAccelerometer
     {
-#if !WINDOWS && !PSM && !XBOX && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
         // the accelerometer sensor on the device
         private static MonoGame.Framework.Devices.Sensors.Accelerometer accelerometer = null;
 #endif
@@ -22,7 +22,7 @@ namespace Cocos2D
 
         static CCAccelerometer()
         {
-#if !WINDOWS && !PSM && !XBOX && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
             try
             {
                 if (MonoGame.Framework.Devices.Sensors.Accelerometer.IsSupported)
@@ -56,7 +56,7 @@ namespace Cocos2D
 
             if (pDelegate != null && !m_bActive)
             {
-#if !WINDOWS && !PSM && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
                     try
                 {
                     if (accelerometer != null && MonoGame.Framework.Devices.Sensors.Accelerometer.IsSupported)
@@ -90,7 +90,7 @@ namespace Cocos2D
             {
                 if (m_bActive && !m_bEmulation)
                 {
-#if !WINDOWS && !PSM && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
                     //if (accelerometer != null)
                     //{
                     //    accelerometer.CurrentValueChanged -= accelerometer_CurrentValueChanged;
@@ -107,7 +107,7 @@ namespace Cocos2D
         }
 
 
-#if !WINDOWS && !PSM && !XBOX360 &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
         private void accelerometer_CurrentValueChanged(object sender, MonoGame.Framework.Devices.Sensors.SensorReadingEventArgs<MonoGame.Framework.Devices.Sensors.AccelerometerReading> e)
         {
 

--- a/cocos2d/text_input_node/CCTextFieldTTF.cs
+++ b/cocos2d/text_input_node/CCTextFieldTTF.cs
@@ -149,9 +149,7 @@ namespace Cocos2D
         {
             if (m_pGuideShowHandle != null)
 			{
-#if !WINDOWS_PHONE && !XBOX && !PSM
 				//Guide.EndShowKeyboardInput(m_pGuideShowHandle);
-#endif
                 m_pGuideShowHandle = null;
             }
 


### PR DESCRIPTION
## What
- **CCAccelerometer**: trim dead `WINDOWS_PHONE`/`PSM`/`XBOX`/`XBOX360` from the 5 sensor `#if`
  conditions → `!WINDOWS && !NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX` (active/gated guards kept).
- **CCLayer**: `!PSM && !NETFX_CORE` → `!NETFX_CORE` (×2); unwrap always-true `#if !PSM` in the
  `AccelerometerEnabled` getter (keep the active return).
- **CCTextFieldTTF**: unwrap always-true `#if !WINDOWS_PHONE && !XBOX && !PSM` (commented-out Guide call).

## Notes
- Behavior-identical (dead symbols undefined in all builds); 111 tests green; these 3 files now free of dead symbols.
