### PR TITLE
refactor: simplify/unwrap dead conditionals in CCUtils

### DIFF
--- a/cocos2d/support/CCUtils.cs
+++ b/cocos2d/support/CCUtils.cs
@@ -23,7 +23,7 @@ THE SOFTWARE.
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using System.Globalization;
-#if !WINDOWS_PHONE && !XBOX && !WINDOWS &&!NETFX_CORE && !PSM
+#if !WINDOWS &&!NETFX_CORE
 #if WINDOWSGL || LINUX
 using OpenTK.Graphics.OpenGL;
 #else
@@ -48,7 +48,6 @@ namespace Cocos2D
     public class CCUtils
     {
 
-        #if !WINDOWS_PHONE && !XBOX && !PSM
         #if OPENGL
         private static List<string> _GLExtensions = null;
         
@@ -97,7 +96,6 @@ namespace Cocos2D
             }
             return _GLExtensions;
         }
-        #endif
         #endif
         
         /// <summary>

--- a/cocos2d/support/CCUtils.cs
+++ b/cocos2d/support/CCUtils.cs
@@ -23,7 +23,7 @@ THE SOFTWARE.
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using System.Globalization;
-#if !WINDOWS &&!NETFX_CORE
+#if !WINDOWS && !NETFX_CORE
 #if WINDOWSGL || LINUX
 using OpenTK.Graphics.OpenGL;
 #else
@@ -50,7 +50,7 @@ namespace Cocos2D
 
         #if OPENGL
         private static List<string> _GLExtensions = null;
-        
+
         public static List<string> GetGLExtensions()
         {
             // Setup extensions.
@@ -63,14 +63,14 @@ namespace Cocos2D
                 if (error != ErrorCode.NoError)
                     CCLog.Log("ERROR: The GL context is in error (" + error + ").");
 #else
-                var extstring = GL.GetString(StringName.Extensions); 
-                All error = (RenderbufferTarget)GL.GetError(); 
+                var extstring = GL.GetString(StringName.Extensions);
+                All error = (RenderbufferTarget)GL.GetError();
                 if (error != All.False)
                     CCLog.Log("ERROR: The GL context is in error (" + error + ").");
 #endif
                 #elif MACOS
 
-				// for right now there are errors with GL before we even get here so the 
+				// for right now there are errors with GL before we even get here so the
 				// CheckGLError for MACOS is throwing errors even though the extensions are read
 				// correctly.  Placed this here for now so that we can continue the processing
 				// until we find the real error.
@@ -97,7 +97,7 @@ namespace Cocos2D
             return _GLExtensions;
         }
         #endif
-        
+
         /// <summary>
         /// Returns the Cardinal Spline position for a given set of control points, tension and time
         /// </summary>
@@ -112,23 +112,23 @@ namespace Cocos2D
         {
             float t2 = t * t;
             float t3 = t2 * t;
-            
+
             /*
              * Formula: s(-ttt + 2tt - t)P1 + s(-ttt + tt)P2 + (2ttt - 3tt + 1)P2 + s(ttt - 2tt + t)P3 + (-2ttt + 3tt)P3 + s(ttt - tt)P4
              */
             float s = (1 - tension) / 2;
-            
+
             float b1 = s * ((-t3 + (2 * t2)) - t); // s(-t3 + 2 t2 - t)P1
             float b2 = s * (-t3 + t2) + (2 * t3 - 3 * t2 + 1); // s(-t3 + t2)P2 + (2 t3 - 3 t2 + 1)P2
             float b3 = s * (t3 - 2 * t2 + t) + (-2 * t3 + 3 * t2); // s(t3 - 2 t2 + t)P3 + (-2 t3 + 3 t2)P3
             float b4 = s * (t3 - t2); // s(t3 - t2)P4
-            
+
             float x = (p0.X * b1 + p1.X * b2 + p2.X * b3 + p3.X * b4);
             float y = (p0.Y * b1 + p1.Y * b2 + p2.Y * b3 + p3.Y * b4);
-            
+
             return new CCPoint(x, y);
         }
-        
+
         /// <summary>
         /// Parses an int value using the default number style and the invariant culture parser.
         /// </summary>
@@ -141,7 +141,7 @@ namespace Cocos2D
             // https://github.com/cocos2d/cocos2d-x-for-xna/issues/17
             return int.Parse(toParse, CultureInfo.InvariantCulture);
         }
-        
+
         /// <summary>
         /// Parses aint value for the given string using the given number style and using
         /// the invariant culture parser.
@@ -156,7 +156,7 @@ namespace Cocos2D
             // https://github.com/cocos2d/cocos2d-x-for-xna/issues/17
             return int.Parse(toParse, ns, CultureInfo.InvariantCulture);
         }
-        
+
         /// <summary>
         /// Parses a float value using the default number style and the invariant culture parser.
         /// </summary>
@@ -169,7 +169,7 @@ namespace Cocos2D
             // https://github.com/cocos2d/cocos2d-x-for-xna/issues/17
             return float.Parse(toParse, CultureInfo.InvariantCulture);
         }
-        
+
         /// <summary>
         /// Parses a float value for the given string using the given number style and using
         /// the invariant culture parser.
@@ -183,7 +183,7 @@ namespace Cocos2D
             // https://github.com/cocos2d/cocos2d-x-for-xna/issues/17
             return float.Parse(toParse, ns, CultureInfo.InvariantCulture);
         }
-        
+
         /// <summary>
         /// Returns the next Power of Two for the given value. If x = 3, then this returns 4.
         /// If x = 4 then 4 is returned. If the value is a power of two, then the same value
@@ -201,7 +201,7 @@ namespace Cocos2D
             x = x | (x >> 16);
             return x + 1;
         }
-        
+
         /// <summary>
         /// Returns the next Power of Two for the given value. If x = 3, then this returns 4.
         /// If x = 4 then 4 is returned. If the value is a power of two, then the same value
@@ -234,7 +234,7 @@ namespace Cocos2D
 				nbegin = nend + token.Length;
 			}
 		}
-		
+
 		// first, judge whether the form of the string like this: {x,y}
 		// if the form is right,the string will be splited into the parameter strs;
 		// or the parameter strs will be empty.
@@ -242,24 +242,24 @@ namespace Cocos2D
 		public static bool SplitWithForm(string pStr, List<string> strs)
 		{
 			bool bRet = false;
-			
+
 			do
 			{
 				if (pStr == null)
 				{
 					break;
 				}
-				
+
 				// string is empty
 				string content = pStr;
 				if (content.Length == 0)
 				{
 					break;
 				}
-				
+
 				int nPosLeft = content.IndexOf('{');
 				int nPosRight = content.IndexOf('}');
-				
+
 				// don't have '{' and '}'
 				if (nPosLeft == -1 || nPosRight == -1)
 				{
@@ -270,29 +270,29 @@ namespace Cocos2D
 				{
 					break;
 				}
-				
+
 				string pointStr = content.Substring(nPosLeft + 1, nPosRight - nPosLeft - 1);
 				// nothing between '{' and '}'
 				if (pointStr.Length == 0)
 				{
 					break;
 				}
-				
+
 				int nPos1 = pointStr.IndexOf('{');
 				int nPos2 = pointStr.IndexOf('}');
-				// contain '{' or '}' 
+				// contain '{' or '}'
 				if (nPos1 != -1 || nPos2 != -1) break;
-				
+
 				Split(pointStr, ",", strs);
 				if (strs.Count != 2 || strs[0].Length == 0 || strs[1].Length == 0)
 				{
 					strs.Clear();
 					break;
 				}
-				
+
 				bRet = true;
 			} while (false);
-			
+
 			return bRet;
 		}
     }


### PR DESCRIPTION
## What
- Import region: `#if !WINDOWS_PHONE && !XBOX && !WINDOWS && !NETFX_CORE && !PSM` → `#if !WINDOWS && !NETFX_CORE`.
- `GetGLExtensions`: unwrap the always-true `#if !WINDOWS_PHONE && !XBOX && !PSM` — removed the outer
  `#if`/`#endif`, kept the inner `#if OPENGL … #endif` (and its `GLES`/`IOS`/`MACOS` nesting) intact.

## Notes
- Behavior-identical; 111 tests green; `CCUtils` now free of dead symbols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform compatibility requirements for OpenGL extension functionality to support a broader range of target platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->