### PR TITLE
refactor: remove dead WINDOWS_PHONE/PSM conditionals in CCDrawManager

### DIFF
--- a/cocos2d/platform/CCDrawManager.cs
+++ b/cocos2d/platform/CCDrawManager.cs
@@ -1345,7 +1345,6 @@ namespace Cocos2D
             bool p = (supportedOrientations & DisplayOrientation.Portrait) == DisplayOrientation.Portrait;
 
             bool onlyLandscape = (ll || lr) && !p;
-            bool onlyPortrait = !(ll || lr) && p;
 #if WINDOWS || WINDOWSGL || MACOS || LINUX
             bool bSwapDims = bUpdateDimensions && ((m_GraphicsDeviceMgr.SupportedOrientations & supportedOrientations) == DisplayOrientation.Default);
 #else

--- a/cocos2d/platform/CCDrawManager.cs
+++ b/cocos2d/platform/CCDrawManager.cs
@@ -389,7 +389,7 @@ namespace Cocos2D
 
             m_Game = game;
 
-#if ANDROID || WINDOWS_PHONE
+#if ANDROID
             graphics.IsFullScreen = true;
 #endif
 
@@ -482,7 +482,7 @@ namespace Cocos2D
             {
                 DepthBufferEnable = false
             };
-#if !WINDOWS_PHONE && !XBOX && !WINDOWS &&!NETFX_CORE && !PSM
+#if !WINDOWS &&!NETFX_CORE
             //List<string> extensions = CCUtils.GetGLExtensions();
             //foreach(string s in extensions) 
             //{
@@ -1346,7 +1346,7 @@ namespace Cocos2D
 
             bool onlyLandscape = (ll || lr) && !p;
             bool onlyPortrait = !(ll || lr) && p;
-#if WINDOWS || WINDOWSGL || WINDOWS_PHONE || MACOS || LINUX
+#if WINDOWS || WINDOWSGL || MACOS || LINUX
             bool bSwapDims = bUpdateDimensions && ((m_GraphicsDeviceMgr.SupportedOrientations & supportedOrientations) == DisplayOrientation.Default);
 #else
             bool bSwapDims = bUpdateDimensions && ((m_GraphicsDeviceMgr.SupportedOrientations & supportedOrientations) == 0);
@@ -1354,7 +1354,7 @@ namespace Cocos2D
             if (bSwapDims && (ll || lr))
             {
                 // Check for landscape changes that do not need a swap
-#if WINDOWS || WINDOWSGL || WINDOWS_PHONE || MACOS || LINUX
+#if WINDOWS || WINDOWSGL || MACOS || LINUX
                 if (((m_GraphicsDeviceMgr.SupportedOrientations & DisplayOrientation.LandscapeLeft) != DisplayOrientation.Default) ||
                     ((m_GraphicsDeviceMgr.SupportedOrientations & DisplayOrientation.LandscapeRight) != DisplayOrientation.Default))
 #else
@@ -1393,27 +1393,6 @@ namespace Cocos2D
             m_GraphicsDeviceMgr.SupportedOrientations = supportedOrientations;
 #endif
 
-#if WINDOWS_PHONE
-            if (bSwapDims)
-            {
-                m_GraphicsDeviceMgr.PreferredBackBufferWidth = preferredBackBufferHeight;
-                m_GraphicsDeviceMgr.PreferredBackBufferHeight = preferredBackBufferWidth;
-            }
-            else
-            {
-                if (onlyLandscape)
-                {
-                    m_GraphicsDeviceMgr.PreferredBackBufferWidth = 800;
-                    m_GraphicsDeviceMgr.PreferredBackBufferHeight = 480;
-                }
-                else if (onlyPortrait)
-                {
-                    m_GraphicsDeviceMgr.PreferredBackBufferWidth = 480;
-                    m_GraphicsDeviceMgr.PreferredBackBufferHeight = 800;
-                }
-            }
-            m_GraphicsDeviceMgr.SupportedOrientations = supportedOrientations;
-#endif
 #if IOS || IPHONE
             if (bSwapDims)
             {
@@ -2209,26 +2188,12 @@ namespace Cocos2D
         {
             UpdateBuffer(0, _data.Count);
         }
-#if PSM
-		private ushort[] _PSMTmpBuffer;
-#endif
-		
+
         public void UpdateBuffer(int startIndex, int elementCount)
         {
             if (elementCount > 0)
             {
-#if PSM
-				// HACK! PSM vertexbuffer only allows for ushort so we have to convert to ushort here.
-				if(_PSMTmpBuffer == null || _PSMTmpBuffer.Length < elementCount) {
-					_PSMTmpBuffer = new ushort[elementCount];
-				}
-				for(int i=0; i < elementCount; i++) {
-					_PSMTmpBuffer[i] = (ushort)Convert.ChangeType(_data.Elements[startIndex+i], TypeCode.UInt16);
-				}
-                _indexBuffer.SetData(_PSMTmpBuffer, 0, elementCount);
-#else
                 _indexBuffer.SetData(_data.Elements, startIndex, elementCount);
-#endif
             }
         }
 


### PR DESCRIPTION
## What
- Simplify mixed conditions (drop dead terms, keep active/gated): `ANDROID || WINDOWS_PHONE` →
  `ANDROID`; `!WINDOWS_PHONE && !XBOX && !WINDOWS && !NETFX_CORE && !PSM` → `!WINDOWS && !NETFX_CORE`;
  trim `WINDOWS_PHONE` from the `WINDOWS||WINDOWSGL||…||MACOS||LINUX` orientation guards (×2).
- Delete pure-dead blocks: the `#if WINDOWS_PHONE` back-buffer-sizing block, and the two `#if PSM`
  index-buffer blocks (keeping the active `#else` `SetData` path).

## Notes
- Behavior-identical; 111 tests green; `CCDrawManager` now free of dead symbols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal platform-specific logic and compilation branches for improved maintainability.
  * Removed legacy platform support code.
  * Streamlined graphics buffer operations for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->