### PR TITLE
refactor: resolve dead WINDOWS_PHONE/XBOX360 conditionals in CCTask

### DIFF
--- a/cocos2d/platform/CCTask.cs
+++ b/cocos2d/platform/CCTask.cs
@@ -1,9 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
-using Microsoft.Xna.Framework.Graphics;
 
 namespace Cocos2D
 {
@@ -22,13 +18,18 @@ namespace Cocos2D
             }
 
             /// <summary>
-            /// Throws an exception if the code is not currently running on the UI thread.
+            /// No-op on current platforms. Historically this enforced that the caller was running
+            /// on the UI thread (Windows Phone); current targets have no separate UI thread.
             /// </summary>
-            /// <exception cref="InvalidOperationException">Thrown if the code is not currently running on the UI thread.</exception>
             public static void EnsureUIThread()
             {
             }
 
+            /// <summary>
+            /// Runs the given action on the UI thread. On current platforms there is no separate
+            /// UI thread, so the action runs immediately on the calling thread.
+            /// </summary>
+            /// <param name="action">The action to run.</param>
             public static void RunOnUiThread(Action action)
             {
                 action();
@@ -55,17 +56,33 @@ namespace Cocos2D
 
         private static ICCSelectorProtocol _taskSelector = new TaskSelector();
 
+        /// <summary>
+        /// Schedules the given action to run on the next scheduler tick (the main loop).
+        /// </summary>
+        /// <param name="action">The action to run.</param>
         public static void RunOnScheduler(Action action)
         {
             var scheduler = CCDirector.SharedDirector.Scheduler;
             scheduler.ScheduleSelector(f => action(), _taskSelector, 0, 0, 0, false);
         }
 
+        /// <summary>
+        /// Runs the given action asynchronously on a background <see cref="Task"/>.
+        /// </summary>
+        /// <param name="action">The action to run in the background.</param>
+        /// <returns>The started background task.</returns>
         public static object RunAsync(Action action)
         {
             return RunAsync(action, null);
         }
 		
+        /// <summary>
+        /// Runs the given action asynchronously on a background <see cref="Task"/>, then optionally
+        /// invokes a completion callback via the scheduler (the main loop).
+        /// </summary>
+        /// <param name="action">The action to run in the background.</param>
+        /// <param name="taskCompleted">Optional callback invoked on the scheduler after the action completes.</param>
+        /// <returns>The started background task.</returns>
         public static object RunAsync(Action action, Action<object> taskCompleted)
         {
             var task = new Task(

--- a/cocos2d/platform/CCTask.cs
+++ b/cocos2d/platform/CCTask.cs
@@ -1,9 +1,5 @@
 using System;
-#if WINDOWS_PHONE|| XBOX360
-using System.ComponentModel;
-#else
 using System.Threading.Tasks;
-#endif
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -21,11 +17,7 @@ namespace Cocos2D
             /// <returns>true if the code is currently running on the UI thread.</returns>
             public static bool IsOnUIThread()
             {
-#if MONOGAME && WINDOWS_PHONE
-                return (Microsoft.Xna.Framework.Threading.IsOnUIThread());
-#else
                 return (true);
-#endif
 
             }
 
@@ -35,32 +27,12 @@ namespace Cocos2D
             /// <exception cref="InvalidOperationException">Thrown if the code is not currently running on the UI thread.</exception>
             public static void EnsureUIThread()
             {
-#if MONOGAME && WINDOWS_PHONE
-                Microsoft.Xna.Framework.Threading.EnsureUIThread();
-#endif
             }
 
             public static void RunOnUiThread(Action action)
             {
-#if WINDOWS_PHONE && MONOGAME
-                Microsoft.Xna.Framework.Threading.RunOnUIThread(action);
-#else
                 action();
-#endif
             }
-
-#if WINDOWS_PHONE && !XNA
-
-            public static void RunOnContainerThread(System.Windows.Threading.Dispatcher target, Action action)
-            {
-                Microsoft.Xna.Framework.Threading.RunOnContainerThread(target, action);
-            }
-
-            public static void BlockOnContainerThread(System.Windows.Threading.Dispatcher target, Action action)
-            {
-                Microsoft.Xna.Framework.Threading.BlockOnContainerThread(target, action);
-            }
-#endif
 
             /// <summary>
             /// Runs the given action on the UI thread and blocks the current thread while the action is running.
@@ -69,11 +41,7 @@ namespace Cocos2D
             /// <param name="action">The action to be run on the UI thread</param>
             public static void BlockOnUIThread(Action action)
             {
-#if WINDOWS_PHONE && MONOGAME
-                Microsoft.Xna.Framework.Threading.BlockOnUIThread(action);
-#else
                 action();
-#endif
             }
 
         #endregion
@@ -100,29 +68,6 @@ namespace Cocos2D
 		
         public static object RunAsync(Action action, Action<object> taskCompleted)
         {
-#if WINDOWS_PHONE || XBOX360
-            var worker = new BackgroundWorker();
-            
-            worker.DoWork +=
-                (sender, args) =>
-                {
-                    action();
-                };
-
-            if (taskCompleted != null)
-            {
-                worker.RunWorkerCompleted +=
-                    (sender, args) =>
-                    {
-                        var scheduler = CCDirector.SharedDirector.Scheduler;
-                        scheduler.ScheduleSelector(f => taskCompleted(worker), _taskSelector, 0, 0, 0, false);
-                    };
-            }
-
-            worker.RunWorkerAsync();
-
-            return worker;
-#else
             var task = new Task(
                 () =>
                 {
@@ -135,11 +80,10 @@ namespace Cocos2D
                     }
                 }
                 );
-                    
+
             task.Start();
 
             return task;
-#endif
         }
     }
 }


### PR DESCRIPTION
## What
Resolves the dead Windows Phone / Xbox 360 threading conditionals to their active branches,
leaving clean `System.Threading.Tasks` code:
- `using System.Threading.Tasks` (drop the `BackgroundWorker` using)
- `IsOnUIThread()` → `return true`; `EnsureUIThread()` → no-op
- `RunOnUiThread`/`BlockOnUIThread` → call `action()` directly
- `RunAsync` → `Task`-based path
- Delete the WP-only `RunOnContainerThread`/`BlockOnContainerThread` (`System.Windows.Threading`, never compiled)

## Notes
- Behavior-identical on all builds (`WINDOWS_PHONE`/`XBOX360` never defined); 111 tests green; `CCTask` now free of dead symbols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and unified threading utilities by consolidating platform-specific thread handling logic into a single, consistent implementation approach. Async operations now use a standardized task-based execution model, streamlining internal thread management while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->