### PR TITLE
refactor: drop dead commented-out ArrayList/Hashtable plist operators

### DIFF
--- a/cocos2d/platform/PList/PlistObjectBase.cs
+++ b/cocos2d/platform/PList/PlistObjectBase.cs
@@ -76,17 +76,6 @@ namespace Cocos2D
 		{
 			return new PlistArray (value);
 		}
-        /*
-        public static implicit operator PlistObjectBase(ArrayList value)
-		{
-			return new PlistArray (value);
-		}
-
-		public static implicit operator PlistObjectBase (Hashtable value)
-		{
-			return new PlistDictionary (value);
-		}
-        */
 
         public abstract byte[] AsBinary { get; }
 	    public abstract int AsInt { get; }


### PR DESCRIPTION
This pull request makes a minor cleanup to the `PlistObjectBase` class by removing commented-out implicit operator overloads for `ArrayList` and `Hashtable`. This helps keep the codebase clean and focused on currently supported conversions.

* Removed commented-out implicit operator overloads for `ArrayList` and `Hashtable` from `PlistObjectBase`, leaving only the supported conversion from `object[]` to `PlistArray`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed commented-out code to improve codebase cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->