### PR TITLE
test: add BenchmarkDotNet project for perf-sensitive BCL swaps

### DIFF
--- a/Tests/Cocos2DMono.Benchmarks/ArrayPoolBenchmarks.cs
+++ b/Tests/Cocos2DMono.Benchmarks/ArrayPoolBenchmarks.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Cocos2DMono.Benchmarks;
+
+// Defends the planned Cocos2D.ArrayPool<T> -> System.Buffers.ArrayPool<T> swap (Phase 2.2).
+// Compares a rent/return cycle of the custom pool against the BCL shared pool.
+// (Types are fully qualified to disambiguate Cocos2D.ArrayPool from System.Buffers.ArrayPool.)
+[MemoryDiagnoser]
+public class ArrayPoolBenchmarks
+{
+    [Params(256)]
+    public int Size;
+
+    [Benchmark(Baseline = true)]
+    public int Custom_CreateFree()
+    {
+        int[] array = Cocos2D.ArrayPool<int>.Create(Size);
+        Cocos2D.ArrayPool<int>.Free(array);
+        return array.Length;
+    }
+
+    [Benchmark]
+    public int Shared_RentReturn()
+    {
+        var pool = System.Buffers.ArrayPool<int>.Shared;
+        int[] array = pool.Rent(Size);
+        pool.Return(array);
+        return array.Length;
+    }
+}

--- a/Tests/Cocos2DMono.Benchmarks/CCRawListBenchmarks.cs
+++ b/Tests/Cocos2DMono.Benchmarks/CCRawListBenchmarks.cs
@@ -54,7 +54,8 @@ public class CCRawListBenchmarks
     public long Iterate_List_Indexer()
     {
         long sum = 0;
-        for (int i = 0; i < _list.Count; i++)
+        int count = _list.Count;
+        for (int i = 0; i < count; i++)
             sum += _list[i];
         return sum;
     }

--- a/Tests/Cocos2DMono.Benchmarks/CCRawListBenchmarks.cs
+++ b/Tests/Cocos2DMono.Benchmarks/CCRawListBenchmarks.cs
@@ -1,0 +1,79 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Cocos2D;
+
+namespace Cocos2DMono.Benchmarks;
+
+// Defends the planned CCRawList<T> -> List<T> swap (Phase 2.2). Compares the render
+// hot-path iteration - CCRawList.Elements direct array access - against
+// List<T> + CollectionsMarshal.AsSpan and the plain List indexer, plus Add throughput.
+// The plan's "+-5%" bar can be checked against these numbers before swapping.
+[MemoryDiagnoser]
+public class CCRawListBenchmarks
+{
+    [Params(1000)]
+    public int N;
+
+    private CCRawList<int> _rawList = null!;
+    private List<int> _list = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawList = new CCRawList<int>();
+        _list = new List<int>();
+        for (int i = 0; i < N; i++)
+        {
+            _rawList.Add(i);
+            _list.Add(i);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public long Iterate_CCRawList_Elements()
+    {
+        long sum = 0;
+        int[] elements = _rawList.Elements;
+        int count = _rawList.count;
+        for (int i = 0; i < count; i++)
+            sum += elements[i];
+        return sum;
+    }
+
+    [Benchmark]
+    public long Iterate_List_AsSpan()
+    {
+        long sum = 0;
+        var span = CollectionsMarshal.AsSpan(_list);
+        for (int i = 0; i < span.Length; i++)
+            sum += span[i];
+        return sum;
+    }
+
+    [Benchmark]
+    public long Iterate_List_Indexer()
+    {
+        long sum = 0;
+        for (int i = 0; i < _list.Count; i++)
+            sum += _list[i];
+        return sum;
+    }
+
+    [Benchmark]
+    public CCRawList<int> Add_CCRawList()
+    {
+        var list = new CCRawList<int>();
+        for (int i = 0; i < N; i++)
+            list.Add(i);
+        return list;
+    }
+
+    [Benchmark]
+    public List<int> Add_List()
+    {
+        var list = new List<int>();
+        for (int i = 0; i < N; i++)
+            list.Add(i);
+        return list;
+    }
+}

--- a/Tests/Cocos2DMono.Benchmarks/Cocos2DMono.Benchmarks.csproj
+++ b/Tests/Cocos2DMono.Benchmarks/Cocos2DMono.Benchmarks.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <!--
+    References the existing DesktopGL build for the types under benchmark
+    (CCRawList<T>, Cocos2D.ArrayPool<T>). These are pure-CPU benchmarks that run
+    headless. Render-loop / action-manager benchmarks (which need a GraphicsDevice)
+    can be added later. Run on demand from this project folder with:
+        dotnet run -c Release
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\cocos2d\cocos2d.DesktopGL\cocos2d.DesktopGL.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Cocos2DMono.Benchmarks/Program.cs
+++ b/Tests/Cocos2DMono.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(System.Reflection.Assembly.GetExecutingAssembly()).Run(args);


### PR DESCRIPTION
This pull request introduces a new benchmarking project, `Cocos2DMono.Benchmarks`, to evaluate the performance of planned internal refactorings for the Cocos2DMono library. It adds benchmarks comparing custom collection and array pool implementations to their standard .NET alternatives, and sets up the necessary project infrastructure for running these benchmarks using BenchmarkDotNet.

**Benchmarking infrastructure:**

* Added a new project file `Cocos2DMono.Benchmarks.csproj` targeting .NET 9, referencing BenchmarkDotNet, and linking to the existing Cocos2D.DesktopGL project for access to types under test. This enables running headless, pure-CPU benchmarks on demand.
* Introduced a simple `Program.cs` that uses BenchmarkDotNet to discover and execute all benchmarks in the assembly.

**Array pool benchmarks:**

* Added `ArrayPoolBenchmarks.cs` to measure and compare the performance of the custom `Cocos2D.ArrayPool<T>` against `System.Buffers.ArrayPool<T>`, focusing on rent/return cycles. This supports the planned migration to the standard library pool.

**Collection benchmarks:**

* Added `CCRawListBenchmarks.cs` to compare the custom `CCRawList<T>` with `List<T>` in terms of iteration and add throughput, providing data to justify a potential swap to the standard collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added comprehensive benchmark suite for performance measurement of core system components, including array pool operations and collection iteration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->