### PR TITLE
test: disable xUnit parallelization to fix flaky director tests

### DIFF
--- a/Tests/Cocos2DMono.UnitTests/AssemblyInfo.cs
+++ b/Tests/Cocos2DMono.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+// The CCNode / CCAction / CCScheduler tests exercise the global CCDirector.SharedDirector
+// singleton, whose lazy initializer is not thread-safe: it publishes the static instance
+// (CCDirector.SharedDirector) before Init() populates ActionManager/Scheduler. Under
+// xUnit's default per-class parallelism, one thread could observe the half-initialized
+// director, so the cached m_pActionManager on a freshly constructed CCNode was null and
+// CCNode.RunAction threw an intermittent NullReferenceException.
+//
+// The engine is single-threaded by design (one game loop owns the director), so we
+// serialize the test run rather than the engine. A thread-safe lazy init in the library
+// is handled as a separate change.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
This pull request addresses issues with test reliability in the `Cocos2DMono.UnitTests` project by disabling parallel test execution. This change ensures that tests interacting with the global `CCDirector.SharedDirector` singleton do not interfere with each other, preventing intermittent failures caused by unsafe concurrent initialization.

Test reliability improvements:

* Disabled parallel execution of tests in the `Cocos2DMono.UnitTests` assembly by adding `[assembly: CollectionBehavior(DisableTestParallelization = true)]` to `AssemblyInfo.cs`, ensuring the single-threaded game engine is not accessed concurrently during tests.
* Added detailed comments explaining the thread-safety issue with the `CCDirector.SharedDirector` singleton and the rationale for serializing test execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite stability by preventing intermittent test failures in the unit test assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->