### PR TITLE
fix: make CCDirector.SharedDirector lazy init thread-safe

### DIFF
--- a/cocos2d/CCDirector.cs
+++ b/cocos2d/CCDirector.cs
@@ -38,7 +38,18 @@ namespace Cocos2D
 
     public abstract class CCDirector
     {
-        private static CCDirector s_sharedDirector;
+        // The shared director is created lazily and exactly once. Lazy<T> defaults to
+        // LazyThreadSafetyMode.ExecutionAndPublication, so the instance is published only
+        // after Init() has fully populated it (ActionManager, Scheduler, dispatchers);
+        // concurrent first callers block until then instead of observing a half-built
+        // director (which previously caused an intermittent NullReferenceException when a
+        // CCNode constructed on another thread cached a null ActionManager).
+        private static readonly Lazy<CCDirector> s_sharedDirector = new Lazy<CCDirector>(() =>
+        {
+            var director = new CCDisplayLinkDirector();
+            director.Init();
+            return director;
+        });
 
         private readonly float kDefaultFPS = 60f;
         private readonly List<CCScene> m_pobScenesStack = new List<CCScene>();
@@ -501,16 +512,8 @@ namespace Cocos2D
         /// <value> </value>
         public static CCDirector SharedDirector
         {
-            get
-            {
-                if (s_sharedDirector == null)
-                {
-                    s_sharedDirector = new CCDisplayLinkDirector();
-                    s_sharedDirector.Init();
-                }
-                return s_sharedDirector;
-            }
-            }
+            get { return s_sharedDirector.Value; }
+        }
 
         public virtual bool NeedsInit
         {


### PR DESCRIPTION
This pull request improves the thread safety and initialization logic of the singleton `CCDirector` instance. The main change is switching from manual lazy initialization to using a `Lazy<T>` object, which ensures that the `CCDirector` is created only once and is fully initialized before being accessed, even in multi-threaded scenarios.

**Singleton initialization improvements:**

* Replaced the manual singleton pattern for `CCDirector` with a `Lazy<CCDirector>` implementation, ensuring thread-safe and fully-initialized access to the shared director. This change prevents possible `NullReferenceException` issues when accessing the director from multiple threads.
* Updated the `SharedDirector` property to return the value from the `Lazy<CCDirector>` instance, simplifying access and guaranteeing proper initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal singleton initialization for enhanced reliability and thread-safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->