### PR TITLE
fix: correct CCInputState frame delta; align CCUserDefault storage guard

### DIFF
--- a/cocos2d/platform/CCApplication.cs
+++ b/cocos2d/platform/CCApplication.cs
@@ -164,7 +164,7 @@ namespace Cocos2D
             }
             if (UseInputStateManagement)
             {
-                CCInputState.Instance.Update(1f / (float)gameTime.ElapsedGameTime.Milliseconds);
+                CCInputState.Instance.Update((float)gameTime.ElapsedGameTime.TotalSeconds);
 #if WINDOWS || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
                 ProcessMouse(CCInputState.Instance.Mouse);
 #else

--- a/cocos2d/support/CCUserDefault.cs
+++ b/cocos2d/support/CCUserDefault.cs
@@ -26,7 +26,7 @@ THE SOFTWARE.
 using System;
 using Cocos2D;
 using System.IO;
-#if ANDROID || IOS || WINDOWSGL
+#if !(WINDOWS || MACOS || LINUX)
 using System.IO.IsolatedStorage;
 #endif
 using System.Collections.Generic;
@@ -44,7 +44,7 @@ namespace Cocos2D
     	private static string USERDEFAULT_ROOT_NAME = "userDefaultRoot";
     	private static string XML_FILE_NAME = "UserDefault.xml";
 
-#if ANDROID || IOS || WINDOWSGL
+#if !(WINDOWS || MACOS || LINUX)
         private IsolatedStorageFile myIsolatedStorage;
     #endif
         private Dictionary<string, string> values = new Dictionary<string, string>();


### PR DESCRIPTION
This pull request focuses on improving platform-specific code handling and correcting time calculation logic in the input state management. The most significant changes are related to platform checks for file storage and improving input state update accuracy.

Platform-specific storage handling:

* Changed preprocessor directives in `CCUserDefault.cs` to use isolated storage only on platforms that are not Windows, MacOS, or Linux, improving cross-platform compatibility. [[1]](diffhunk://#diff-5f8f93b08686960586a7003c13a7f42f29a60ec71c219a6c09688ded0de2cc47L29-R29) [[2]](diffhunk://#diff-5f8f93b08686960586a7003c13a7f42f29a60ec71c219a6c09688ded0de2cc47L47-R47)

Input state update logic:

* Updated the `Update` method in `CCApplication.cs` to use `TotalSeconds` instead of calculating seconds from milliseconds, ensuring more accurate and reliable input state updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined input timing calculations for more consistent input handling.
  * Expanded platform support for data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->