### PR TITLE
refactor: remove dead UWP conditionals from device/geometry files

### DIFF
--- a/cocos2d/CCDirector.cs
+++ b/cocos2d/CCDirector.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-#if !NETFX_CORE
 using System.IO.IsolatedStorage;
-#endif
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -65,9 +63,7 @@ namespace Cocos2D
         private bool m_NeedsInit = true;
         internal CCSize m_obWinSizeInPoints;
 		
-#if !NETFX_CORE
         private CCAccelerometer m_pAccelerometer;
-#endif
 		private CCActionManager m_pActionManager;
         private CCKeypadDispatcher m_pKeypadDispatcher;
 		private CCKeyboardDispatcher m_pKeyboardDispatcher;
@@ -100,7 +96,6 @@ namespace Cocos2D
         
         #region State Management
 		
-#if !NETFX_CORE
         private string m_sStorageDirName = "cocos2dDirector";
         private string m_sSaveFileName = "SceneList.dat";
         private string m_sSceneSaveFileName = "Scene{0}.dat";
@@ -335,7 +330,6 @@ namespace Cocos2D
                 storage.DeleteFile(Path.Combine(m_sStorageDirName, file));
             }
                         }
-#endif
         #endregion
 
         public ICCDirectorDelegate Delegate
@@ -454,13 +448,11 @@ namespace Cocos2D
 			set { m_pKeyboardDispatcher = value; }
 		}
 
-#if !NETFX_CORE
 		public CCAccelerometer Accelerometer
         {
             get { return m_pAccelerometer; }
             set { m_pAccelerometer = value; }
         }
-#endif
         public CCScene RunningScene
         {
             get { return m_pRunningScene; }
@@ -578,9 +570,7 @@ namespace Cocos2D
 			m_pKeyboardDispatcher = new CCKeyboardDispatcher();
 
 			// Accelerometer
-#if !NETFX_CORE
             m_pAccelerometer = new CCAccelerometer();
-#endif
 
             m_NeedsInit = false;
             return true;

--- a/cocos2d/cocoa/CCGeometry.cs
+++ b/cocos2d/cocoa/CCGeometry.cs
@@ -31,9 +31,7 @@ using Microsoft.Xna.Framework;
 
 namespace Cocos2D
 {
-#if !NETFX_CORE
     [Serializable, StructLayout(LayoutKind.Sequential), TypeConverter(typeof (CCPointConverter))]
-#endif
     public struct CCPoint
     {
         public static readonly CCPoint Zero = new CCPoint(0, 0);
@@ -666,11 +664,7 @@ namespace Cocos2D
 
         public static CCPoint Parse(string s)
         {
-#if !NETFX_CORE
             return (CCPoint) TypeDescriptor.GetConverter(typeof (CCPoint)).ConvertFromString(s);
-#else
-            return (CCPointConverter.CCPointFromString(s));
-#endif
         }
 
         public static implicit operator CCPoint(Vector2 point)
@@ -689,9 +683,7 @@ namespace Cocos2D
         }
     }
 
-#if !NETFX_CORE
     [Serializable, StructLayout(LayoutKind.Sequential), TypeConverter(typeof (CCSizeConverter))]
-#endif
     public struct CCSize
     {
         public static readonly CCSize Zero = new CCSize(0, 0);
@@ -799,11 +791,7 @@ namespace Cocos2D
 
         public static CCSize Parse(string s)
         {
-#if !NETFX_CORE
             return (CCSize) TypeDescriptor.GetConverter(typeof (CCSize)).ConvertFromString(s);
-#else
-            return (CCSizeConverter.CCSizeFromString(s));
-#endif
         }
 
         /**
@@ -827,9 +815,7 @@ namespace Cocos2D
         }
     }
 
-#if !NETFX_CORE
     [Serializable, StructLayout(LayoutKind.Sequential), TypeConverter(typeof (CCRectConverter))]
-#endif
     public struct CCRect
     {
         public static readonly CCRect Zero = new CCRect(0, 0, 0, 0);
@@ -1093,11 +1079,7 @@ namespace Cocos2D
 
         public static CCRect Parse(string s)
         {
-#if !NETFX_CORE
             return (CCRect) TypeDescriptor.GetConverter(typeof (CCRect)).ConvertFromString(s);
-#else
-            return (CCRectConverter.CCRectFromString(s));
-#endif
         }
     }
 

--- a/cocos2d/platform/CCAccelerometer.cs
+++ b/cocos2d/platform/CCAccelerometer.cs
@@ -8,7 +8,7 @@ namespace Cocos2D
 {
     public class CCAccelerometer
     {
-#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
         // the accelerometer sensor on the device
         private static MonoGame.Framework.Devices.Sensors.Accelerometer accelerometer = null;
 #endif
@@ -22,7 +22,7 @@ namespace Cocos2D
 
         static CCAccelerometer()
         {
-#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
             try
             {
                 if (MonoGame.Framework.Devices.Sensors.Accelerometer.IsSupported)
@@ -56,7 +56,7 @@ namespace Cocos2D
 
             if (pDelegate != null && !m_bActive)
             {
-#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
                     try
                 {
                     if (accelerometer != null && MonoGame.Framework.Devices.Sensors.Accelerometer.IsSupported)
@@ -90,7 +90,7 @@ namespace Cocos2D
             {
                 if (m_bActive && !m_bEmulation)
                 {
-#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
                     //if (accelerometer != null)
                     //{
                     //    accelerometer.CurrentValueChanged -= accelerometer_CurrentValueChanged;
@@ -107,7 +107,7 @@ namespace Cocos2D
         }
 
 
-#if !WINDOWS &&!NETFX_CORE && !MACOS && !WINDOWSGL && !LINUX
+#if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
         private void accelerometer_CurrentValueChanged(object sender, MonoGame.Framework.Devices.Sensors.SensorReadingEventArgs<MonoGame.Framework.Devices.Sensors.AccelerometerReading> e)
         {
 

--- a/cocos2d/platform/CCInputState.cs
+++ b/cocos2d/platform/CCInputState.cs
@@ -180,7 +180,7 @@ namespace Cocos2D
 
         public readonly bool[] GamePadWasConnected = new bool[MaxInputs];
 
-#if (WINDOWS && !WINRT) || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
+#if WINDOWS || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
         public MouseState CurrentMouseState;
         public MouseState LastMouseState;
 #endif
@@ -206,7 +206,7 @@ namespace Cocos2D
         /// </summary>
         public void Update(float deltaTime)
         {
-#if (WINDOWS && !WINRT) || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
+#if WINDOWS || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
             LastMouseState = CurrentMouseState;
             CurrentMouseState = Microsoft.Xna.Framework.Input.Mouse.GetState();
 #endif
@@ -358,7 +358,7 @@ namespace Cocos2D
 
         #region Mouse
 
-#if (WINDOWS && !WINRT) || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
+#if WINDOWS || WINDOWSGL || MACOS || LINUX || ENABLE_MOUSE
 
         public MouseState Mouse
         {

--- a/cocos2d/textures/CCTexture2D.cs
+++ b/cocos2d/textures/CCTexture2D.cs
@@ -8,7 +8,7 @@ using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-#if (WINDOWS && !WINRT && !WINDOWS_UWP)
+#if WINDOWS
 using BitMiracle.LibTiff.Classic;
 #endif
 
@@ -825,11 +825,7 @@ namespace Cocos2D
                         break;
 
                     case CCTextureCacheType.RawData:
-#if NETFX_CORE
-                    var methodInfo = typeof(CCTexture2D).GetType().GetTypeInfo().GetDeclaredMethod("InitWithRawData");
-#else
                         var methodInfo = typeof(CCTexture2D).GetMethods(BindingFlags.Public | BindingFlags.Instance).First(m => m.Name == "InitWithRawData" && m.IsGenericMethod && m.GetParameters().Length == 7);
-#endif
                         if (methodInfo != null)
                         {
                             var genericMethod = methodInfo.MakeGenericMethod(m_CacheInfo.Data.GetType().GetElementType());
@@ -1064,7 +1060,7 @@ namespace Cocos2D
 
         private Texture2D LoadTextureFromTiff(Stream stream)
         {
-#if (WINDOWS && !WINRT && !WINDOWS_UWP)
+#if WINDOWS
             var tiff = Tiff.ClientOpen("file.tif", "r", stream, new TiffStream());
 
             var w = tiff.GetField(TiffTag.IMAGEWIDTH)[0].ToInt();

--- a/cocos2d/textures/CCTexture2D.cs
+++ b/cocos2d/textures/CCTexture2D.cs
@@ -223,7 +223,7 @@ namespace Cocos2D
                     m_samplerState = SamplerState.PointClamp;
                     return;
                 }
-                
+
                 m_samplerState = new SamplerState
                 {
                     Filter = TextureFilter.Point
@@ -441,7 +441,7 @@ namespace Cocos2D
             try
             {
                 texture = LoadTexture(stream);
-                
+
                 InitWithTexture(texture, pixelFormat, false, false);
 
                 return true;
@@ -525,7 +525,7 @@ namespace Cocos2D
                 }
 
                 float scale = 1f;
-                
+
                 if (loadedSize != 0)
                 {
                     scale = fontSize / loadedSize * CCSpriteFontCache.FontScale;
@@ -795,8 +795,8 @@ namespace Cocos2D
 
         public override void Reinit()
         {
-			CCLog.Log("reinit called on {1} '{0}' {2}", ToString(), 
-                m_CacheInfo.CacheType, 
+			CCLog.Log("reinit called on {1} '{0}' {2}", ToString(),
+                m_CacheInfo.CacheType,
 				(m_CacheInfo.CacheType == CCTextureCacheType.AssetFile || m_CacheInfo.CacheType == CCTextureCacheType.String) ? m_CacheInfo.Data : string.Empty);
 
             Texture2D textureToDispose = null;
@@ -825,7 +825,7 @@ namespace Cocos2D
                         break;
 
                     case CCTextureCacheType.RawData:
-                        var methodInfo = typeof(CCTexture2D).GetMethods(BindingFlags.Public | BindingFlags.Instance).First(m => m.Name == "InitWithRawData" && m.IsGenericMethod && m.GetParameters().Length == 7);
+                        var methodInfo = typeof(CCTexture2D).GetMethods(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(m => m.Name == "InitWithRawData" && m.IsGenericMethod && m.GetParameters().Length == 7);
                         if (methodInfo != null)
                         {
                             var genericMethod = methodInfo.MakeGenericMethod(m_CacheInfo.Data.GetType().GetElementType());
@@ -1074,7 +1074,7 @@ namespace Cocos2D
                 result.SetData(raster);
                 return result;
             }
-			else 
+			else
 			{
 				return null;
 			}
@@ -1086,7 +1086,7 @@ namespace Cocos2D
 #endif
         }
 
-        
+
         #endregion
     }
 


### PR DESCRIPTION
This pull request removes many platform-specific preprocessor directives, especially those related to `NETFX_CORE` and legacy Windows checks, to simplify the codebase and modernize platform targeting. The changes make serialization, accelerometer, and mouse input code more consistent and easier to maintain.

**Platform abstraction and cleanup:**

* Removed most `#if !NETFX_CORE` and related preprocessor conditions from `cocos2d/CCDirector.cs` and `cocos2d/cocoa/CCGeometry.cs`, making features like accelerometer, serialization, and type conversion always available regardless of platform. [[1]](diffhunk://#diff-027094c061f1b7f50a6636db450f4cda2b004346d3b3e57cc6e9c71e27036e92L5-L7) [[2]](diffhunk://#diff-027094c061f1b7f50a6636db450f4cda2b004346d3b3e57cc6e9c71e27036e92L68-L70) [[3]](diffhunk://#diff-027094c061f1b7f50a6636db450f4cda2b004346d3b3e57cc6e9c71e27036e92L103) [[4]](diffhunk://#diff-027094c061f1b7f50a6636db450f4cda2b004346d3b3e57cc6e9c71e27036e92L338) [[5]](diffhunk://#diff-027094c061f1b7f50a6636db450f4cda2b004346d3b3e57cc6e9c71e27036e92L457-L463) [[6]](diffhunk://#diff-027094c061f1b7f50a6636db450f4cda2b004346d3b3e57cc6e9c71e27036e92L581-L583) [[7]](diffhunk://#diff-ecdeefc7c68a9fa22393e81bbd02a2969d793a9f541412b6f54b336a4740c9deL34-L36) [[8]](diffhunk://#diff-ecdeefc7c68a9fa22393e81bbd02a2969d793a9f541412b6f54b336a4740c9deL669-L673) [[9]](diffhunk://#diff-ecdeefc7c68a9fa22393e81bbd02a2969d793a9f541412b6f54b336a4740c9deL692-L694) [[10]](diffhunk://#diff-ecdeefc7c68a9fa22393e81bbd02a2969d793a9f541412b6f54b336a4740c9deL802-L806) [[11]](diffhunk://#diff-ecdeefc7c68a9fa22393e81bbd02a2969d793a9f541412b6f54b336a4740c9deL830-L832) [[12]](diffhunk://#diff-ecdeefc7c68a9fa22393e81bbd02a2969d793a9f541412b6f54b336a4740c9deL1096-L1100)

* Updated platform checks for accelerometer support in `cocos2d/platform/CCAccelerometer.cs` by removing `!NETFX_CORE` and simplifying conditions to only exclude unsupported platforms. [[1]](diffhunk://#diff-664d5d57f82ca4ec495295659bd28b17485a36d7e14a76208057b6df90254cc7L11-R11) [[2]](diffhunk://#diff-664d5d57f82ca4ec495295659bd28b17485a36d7e14a76208057b6df90254cc7L25-R25) [[3]](diffhunk://#diff-664d5d57f82ca4ec495295659bd28b17485a36d7e14a76208057b6df90254cc7L59-R59) [[4]](diffhunk://#diff-664d5d57f82ca4ec495295659bd28b17485a36d7e14a76208057b6df90254cc7L93-R93) [[5]](diffhunk://#diff-664d5d57f82ca4ec495295659bd28b17485a36d7e14a76208057b6df90254cc7L110-R110)

**Input handling improvements:**

* Simplified mouse input platform conditions in `cocos2d/platform/CCInputState.cs` to use `WINDOWS` instead of more complex checks, making mouse support more straightforward. [[1]](diffhunk://#diff-e7f50ac661babf05ce417696c63568a53882d08babf7c170c17a3103068a7ddcL183-R183) [[2]](diffhunk://#diff-e7f50ac661babf05ce417696c63568a53882d08babf7c170c17a3103068a7ddcL209-R209) [[3]](diffhunk://#diff-e7f50ac661babf05ce417696c63568a53882d08babf7c170c17a3103068a7ddcL361-R361)

**Texture and image handling:**

* Simplified TIFF image loading platform check in `cocos2d/textures/CCTexture2D.cs` to use `WINDOWS` only, and removed unnecessary `NETFX_CORE` reflection code for raw data initialization. [[1]](diffhunk://#diff-4fff2854caa989c34d430e680386b360d69964cd067d6334f3ef205bd3d63900L11-R11) [[2]](diffhunk://#diff-4fff2854caa989c34d430e680386b360d69964cd067d6334f3ef205bd3d63900L828-L832) [[3]](diffhunk://#diff-4fff2854caa989c34d430e680386b360d69964cd067d6334f3ef205bd3d63900L1067-R1063)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed conditional compilation directives restricting accelerometer, state persistence, and mouse input functionality to specific build configurations, making these features universally available
  * Expanded TIFF texture loading support across all Windows builds
  * Consolidated platform detection logic for improved consistency across supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->