### PR TITLE
fix: harden CCTouchDelegate handler exec and CCAccelerometer teardown

### DIFF
--- a/cocos2d/platform/CCAccelerometer.cs
+++ b/cocos2d/platform/CCAccelerometer.cs
@@ -91,11 +91,11 @@ namespace Cocos2D
                 if (m_bActive && !m_bEmulation)
                 {
 #if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
-                    //if (accelerometer != null)
-                    //{
-                    //    accelerometer.CurrentValueChanged -= accelerometer_CurrentValueChanged;
-                    //    accelerometer.Stop();
-                    //}
+                    if (accelerometer != null)
+                    {
+                        accelerometer.CurrentValueChanged -= accelerometer_CurrentValueChanged;
+                        accelerometer.Stop();
+                    }
 #endif
                 }
                 

--- a/cocos2d/platform/CCAccelerometer.cs
+++ b/cocos2d/platform/CCAccelerometer.cs
@@ -93,8 +93,15 @@ namespace Cocos2D
 #if !WINDOWS && !MACOS && !WINDOWSGL && !LINUX
                     if (accelerometer != null)
                     {
-                        accelerometer.CurrentValueChanged -= accelerometer_CurrentValueChanged;
-                        accelerometer.Stop();
+                        try
+                        {
+                            accelerometer.CurrentValueChanged -= accelerometer_CurrentValueChanged;
+                            accelerometer.Stop();
+                        }
+                        catch (Exception)
+                        {
+                            // Sensor can be in a bad / partial state on teardown; ignore.
+                        }
                     }
 #endif
                 }

--- a/cocos2d/touch_dispatcher/CCTouchDelegate.cs
+++ b/cocos2d/touch_dispatcher/CCTouchDelegate.cs
@@ -49,18 +49,18 @@ namespace Cocos2D
 
         public void ExcuteScriptTouchHandler(int eventType, CCTouch pTouch)
         {
-            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null)
+            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null && m_pEventTypeFuncMap.TryGetValue(eventType, out var handler))
             {
-                CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine.ExecuteTouchEvent((m_pEventTypeFuncMap)[eventType],
+                CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine.ExecuteTouchEvent(handler,
                                                                                                  pTouch);
             }
         }
 
         public void ExcuteScriptTouchesHandler(int eventType, List<CCTouch> pTouches)
         {
-            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null)
+            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null && m_pEventTypeFuncMap.TryGetValue(eventType, out var handler))
             {
-                CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine.ExecuteTouchesEvent((m_pEventTypeFuncMap)[eventType],
+                CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine.ExecuteTouchesEvent(handler,
                                                                                                    pTouches);
             }
         }

--- a/cocos2d/touch_dispatcher/CCTouchDelegate.cs
+++ b/cocos2d/touch_dispatcher/CCTouchDelegate.cs
@@ -49,7 +49,7 @@ namespace Cocos2D
 
         public void ExcuteScriptTouchHandler(int eventType, CCTouch pTouch)
         {
-            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null && m_pEventTypeFuncMap.TryGetValue(eventType, out var handler))
+            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null && m_pEventTypeFuncMap.TryGetValue(eventType, out var handler) && !string.IsNullOrEmpty(handler))
             {
                 CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine.ExecuteTouchEvent(handler,
                                                                                                  pTouch);
@@ -58,7 +58,7 @@ namespace Cocos2D
 
         public void ExcuteScriptTouchesHandler(int eventType, List<CCTouch> pTouches)
         {
-            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null && m_pEventTypeFuncMap.TryGetValue(eventType, out var handler))
+            if (m_pEventTypeFuncMap != null && CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine != null && m_pEventTypeFuncMap.TryGetValue(eventType, out var handler) && !string.IsNullOrEmpty(handler))
             {
                 CCScriptEngineManager.SharedScriptEngineManager.ScriptEngine.ExecuteTouchesEvent(handler,
                                                                                                    pTouches);


### PR DESCRIPTION
This pull request contains targeted bug fixes and code cleanup for the accelerometer and touch event handler logic. The main changes improve safety and correctness when handling hardware and script events.

**Touch Event Handler Improvements:**

* Updated `ExcuteScriptTouchHandler` and `ExcuteScriptTouchesHandler` in `CCTouchDelegate.cs` to safely check for the existence of a handler using `TryGetValue` before executing script events, preventing potential exceptions if a handler is missing.

**Accelerometer Event Handling Cleanup:**

* Restored the code in `SetDelegate` in `CCAccelerometer.cs` to properly remove the event handler and stop the accelerometer when deactivating, ensuring correct cleanup of resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed accelerometer deactivation so it now properly stops listening and unsubscribes from sensor updates when turned off.
  * Improved touch script handling so callbacks run only when a handler is registered for the event type, avoiding failures when handlers are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->