### PR TITLE
ci: pin unit-tests workflow actions to SHAs; disable credential persistence

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,10 +14,12 @@ jobs:
     name: Unit tests (DesktopGL / net9.0)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: global.json
       - name: Test


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for unit tests to use specific commit SHAs for the `actions/checkout` and `actions/setup-dotnet` actions, and disables credential persistence in the checkout step. These changes improve the security and reproducibility of the workflow.

**Workflow security and reproducibility improvements:**

* Updated `actions/checkout` to use a specific commit SHA (`34e114876b0b11c390a56381ad16ebd13914f8d5`) instead of a version tag, and set `persist-credentials: false` to prevent the action from persisting repository credentials. (.github/workflows/unit-tests.yml)
* Updated `actions/setup-dotnet` to use a specific commit SHA (`67a3573c9a986a3f9c594539f4ab511d57bb3ce9`) instead of a version tag for improved security and reproducibility. (.github/workflows/unit-tests.yml)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build/test workflow to use pinned versions of key automation actions for more consistent runs.
  * No changes to the test steps or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->