### PR TITLE
build: introduce central package management (Stage C1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,36 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- MonoGame (version centralized in Directory.Build.props as $(MonoGameVersion)) -->
+    <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
+    <PackageVersion Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
+    <PackageVersion Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
+    <PackageVersion Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
+    <PackageVersion Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
+
+    <!-- Graphics / imaging -->
+    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.116.1" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.639" />
+
+    <!-- OpenGL / platform services -->
+    <PackageVersion Include="OpenTK" Version="4.9.4" />
+    <PackageVersion Include="Xamarin.Essentials" Version="1.7.5" />
+
+    <!-- Compression -->
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+
+    <!-- Test / benchmark -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,9 @@
     <PackageVersion Include="SkiaSharp" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.116.1" />
+    <!-- Reconciled to 8.0.11 (already used by 6 projects, incl. Linux/macOS); unifies
+         cocos2d.Core.Windows (was 5.0.3) and cocos2d.Windows (was 8.0.8). Both are Windows
+         targets, where System.Drawing.Common 8.x is fully supported. -->
     <PackageVersion Include="System.Drawing.Common" Version="8.0.11" />
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.639" />
 
@@ -23,7 +26,8 @@
     <PackageVersion Include="OpenTK" Version="4.9.4" />
     <PackageVersion Include="Xamarin.Essentials" Version="1.7.5" />
 
-    <!-- Compression -->
+    <!-- Compression. Reconciled to 1.4.2, which the mobile projects already used
+         (the cocos2d desktop / Core projects were on 1.3.3). -->
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
 
     <!-- Test / benchmark -->

--- a/Tests/Cocos2DMono.Benchmarks/Cocos2DMono.Benchmarks.csproj
+++ b/Tests/Cocos2DMono.Benchmarks/Cocos2DMono.Benchmarks.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
 
   <!--

--- a/Tests/Cocos2DMono.UnitTests/Cocos2DMono.UnitTests.csproj
+++ b/Tests/Cocos2DMono.UnitTests/Cocos2DMono.UnitTests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <!--

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Android/cocos2d-mono.Tests.Android.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Android/cocos2d-mono.Tests.Android.csproj
@@ -38,8 +38,8 @@
     <AndroidSupportedAbis />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.Android" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\strings.xml" />

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Android/cocos2d-mono.Tests.Core.Android.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Android/cocos2d-mono.Tests.Core.Android.csproj
@@ -38,7 +38,7 @@
     <AndroidSupportedAbis />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.Android" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\strings.xml" />

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
@@ -67,7 +67,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\animations\animations-2.plist">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Windows/cocos2d-mono.Tests.Core.Windows.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.Windows/cocos2d-mono.Tests.Core.Windows.csproj
@@ -70,7 +70,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\animations\animations-2.plist">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.iOS/cocos2d-mono.Tests.Core.iOS.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Core.iOS/cocos2d-mono.Tests.Core.iOS.csproj
@@ -69,8 +69,8 @@
     </MonoGameContentReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.7.5" />
+    <PackageReference Include="MonoGame.Framework.iOS" />
+    <PackageReference Include="Xamarin.Essentials" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.Core.DesktopGL.csproj
@@ -70,7 +70,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
 </Project>

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.DesktopGL.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.DesktopGL/cocos2d-mono.Tests.DesktopGL.csproj
@@ -66,8 +66,8 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Linux/cocos2d-mono.Tests.Linux.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Linux/cocos2d-mono.Tests.Linux.csproj
@@ -66,8 +66,8 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Windows/cocos2d-mono.Tests.Windows.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.Windows/cocos2d-mono.Tests.Windows.csproj
@@ -72,7 +72,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.iOS/cocos2d-mono.Tests.iOS.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.iOS/cocos2d-mono.Tests.iOS.csproj
@@ -73,9 +73,9 @@
     </MonoGameContentReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.7.5" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.iOS" />
+    <PackageReference Include="Xamarin.Essentials" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">

--- a/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.macOS/cocos2d-mono.Tests.macOS.csproj
+++ b/Tests/cocos2d-mono.Tests/cocos2d-mono.Tests.macOS/cocos2d-mono.Tests.macOS.csproj
@@ -66,8 +66,8 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <Import Project="..\cocos2d-mono.Tests.projitems" Label="Shared" />
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">

--- a/box2d/box2d.Android/box2d.Android.csproj
+++ b/box2d/box2d.Android/box2d.Android.csproj
@@ -52,7 +52,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.Android" />
   </ItemGroup>
   <Import Project="..\box2d.projitems" Label="Shared" />
 </Project>

--- a/box2d/box2d.DesktopGL/box2d.DesktopGL.csproj
+++ b/box2d/box2d.DesktopGL/box2d.DesktopGL.csproj
@@ -60,7 +60,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Logos\logo-small.png">

--- a/box2d/box2d.Windows/box2d.Windows.csproj
+++ b/box2d/box2d.Windows/box2d.Windows.csproj
@@ -61,7 +61,7 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" />
   </ItemGroup>
   <Import Project="..\box2d.projitems" Label="Shared" />
 </Project>

--- a/box2d/box2d.iOS/box2d.iOS.csproj
+++ b/box2d/box2d.iOS/box2d.iOS.csproj
@@ -47,7 +47,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
+    <PackageReference Include="MonoGame.Framework.iOS" />
   </ItemGroup>
   <Import Project="..\box2d.projitems" Label="Shared" />
 </Project>

--- a/cocos2d/cocos2d.Android/cocos2d.Android.csproj
+++ b/cocos2d/cocos2d.Android/cocos2d.Android.csproj
@@ -59,10 +59,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.Android" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />

--- a/cocos2d/cocos2d.Core.Android/cocos2d.Core.Android.csproj
+++ b/cocos2d/cocos2d.Core.Android/cocos2d.Core.Android.csproj
@@ -59,9 +59,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="MonoGame.Framework.Android" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
   <Import Project="..\cocos2d.projitems" Label="Shared" Condition="Exists('..\cocos2d.projitems')" />
 </Project>

--- a/cocos2d/cocos2d.Core.DesktopGL/cocos2d.Core.DesktopGL.csproj
+++ b/cocos2d/cocos2d.Core.DesktopGL/cocos2d.Core.DesktopGL.csproj
@@ -71,14 +71,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.116.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.DesktopGL\box2d.DesktopGL.csproj">

--- a/cocos2d/cocos2d.Core.Linux/cocos2d.Core.Linux.csproj
+++ b/cocos2d/cocos2d.Core.Linux/cocos2d.Core.Linux.csproj
@@ -60,13 +60,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.DesktopGL\box2d.DesktopGL.csproj">

--- a/cocos2d/cocos2d.Core.Windows/cocos2d.Core.Windows.csproj
+++ b/cocos2d/cocos2d.Core.Windows/cocos2d.Core.Windows.csproj
@@ -62,10 +62,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.639" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+    <PackageReference Include="BitMiracle.LibTiff.NET" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.Windows\box2d.Windows.csproj">

--- a/cocos2d/cocos2d.Core.iOS/cocos2d.Core.iOS.csproj
+++ b/cocos2d/cocos2d.Core.iOS/cocos2d.Core.iOS.csproj
@@ -60,9 +60,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="MonoGame.Framework.iOS" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
   <Import Project="..\cocos2d.projitems" Label="Shared" />
 </Project>

--- a/cocos2d/cocos2d.Core.macOS/cocos2d.Core.macOS.csproj
+++ b/cocos2d/cocos2d.Core.macOS/cocos2d.Core.macOS.csproj
@@ -60,13 +60,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.116.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.DesktopGL\box2d.DesktopGL.csproj">

--- a/cocos2d/cocos2d.DesktopGL/cocos2d.DesktopGL.csproj
+++ b/cocos2d/cocos2d.DesktopGL/cocos2d.DesktopGL.csproj
@@ -72,14 +72,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.116.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.DesktopGL\box2d.DesktopGL.csproj">

--- a/cocos2d/cocos2d.Linux/cocos2d.Linux.csproj
+++ b/cocos2d/cocos2d.Linux/cocos2d.Linux.csproj
@@ -61,13 +61,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.DesktopGL\box2d.DesktopGL.csproj">

--- a/cocos2d/cocos2d.Windows/cocos2d.Windows.csproj
+++ b/cocos2d/cocos2d.Windows/cocos2d.Windows.csproj
@@ -62,11 +62,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.639" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+    <PackageReference Include="BitMiracle.LibTiff.NET" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.Windows\box2d.Windows.csproj">

--- a/cocos2d/cocos2d.iOS/cocos2d.iOS.csproj
+++ b/cocos2d/cocos2d.iOS/cocos2d.iOS.csproj
@@ -60,10 +60,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.iOS" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />

--- a/cocos2d/cocos2d.macOS/cocos2d.macOS.csproj
+++ b/cocos2d/cocos2d.macOS/cocos2d.macOS.csproj
@@ -61,13 +61,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
-    <PackageReference Include="OpenTK" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.116.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="OpenTK" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\box2d\box2d.DesktopGL\box2d.DesktopGL.csproj">


### PR DESCRIPTION
This pull request centralizes NuGet package version management for the solution by introducing a `Directory.Packages.props` file. It removes explicit version numbers from individual project files, allowing all package versions to be managed in one place. This makes updating and maintaining dependencies easier and reduces duplication across projects.

Dependency version management:

* Added a new `Directory.Packages.props` file that enables central package version management and defines versions for all shared dependencies, including MonoGame, SkiaSharp, OpenTK, Xamarin.Essentials, SharpZipLib, and test/benchmark libraries.
* Removed explicit version numbers from all `PackageReference` entries in project files, so that versions are now inherited from the central file. [[1]](diffhunk://#diff-fb333c4f9938c1b7d80f9604b06f45e062c553e982ddc2fb91918a31b3bd1fc0L13-R13) [[2]](diffhunk://#diff-299fd45901d7653a2fc9975eb67935f7da4ae55d26002a1b10fbb46ef5c2013eL13-R15) [[3]](diffhunk://#diff-73374eaa0ac6a326c2f18dabe25885deec22e2246d80a5c4fb52549faf4558eeL41-R42) [[4]](diffhunk://#diff-50dbd169af612e7f52501516f3078caebd3b9d53ce3a32434e0ea7a11e9bd8e1L41-R41) [[5]](diffhunk://#diff-a77ee688d0bebc81cd42e8dff2b4bb63790c1594845f440dba4ea7f22a4b5b76L70-R70) [[6]](diffhunk://#diff-aecebcbbca575deff17eae605e96b1b8f11b7dde8fca4fda3b1d214ebc6b5219L73-R73) [[7]](diffhunk://#diff-8e88ea5a4f2a8819bb0b02d8bd7ea209a1120f8f9bab40bc179c1f09081ebba9L72-R73) [[8]](diffhunk://#diff-9fa1a52f4fa346f51dd8099c61312de2658f1251f7636c6577500b7aa06b1151L76-R78) [[9]](diffhunk://#diff-c616daa7c00f57965ffc8158d0b76ecdef3fe116f838c1cc28e5fedfbfe2ca3eL69-R70) [[10]](diffhunk://#diff-8484ca503c878a905da7dbc2f3ec8f12f1641d3026e47dd80d3398b74af673faL69-R70) [[11]](diffhunk://#diff-21a933b0d5f5c7e55743295e36505587e07cc6ff123bedd6d15d7f64c87409a9L69-R70) [[12]](diffhunk://#diff-bdfc0310b05ebac763fec7f37c2a01fc3868bc668448ca868ccc5d1b2e37ffddL75-R75) [[13]](diffhunk://#diff-c7eb80a1ade7e543d010ae2e5b30df425fa7fa27c21fb049ca03e5b98028f69dL55-R55) [[14]](diffhunk://#diff-04cd206d428bcc56f4106120e8ffce68e95ec577a06f2c918b1dd1429d46b4e1L63-R63) [[15]](diffhunk://#diff-67fcd2ea7c361a881b430859cb7c1ef9db2563522c2af68d38a51b10c2f52b33L64-R64) [[16]](diffhunk://#diff-847eb4777b9efa9363a1c9eb0b77bf2ee5f5c70cbb34281788896f15bbb491beL50-R50) [[17]](diffhunk://#diff-525ea9f6a7daa66d2ae31d94af88c9b313d77210c5ebdf0b835139637df4a308L62-R65) [[18]](diffhunk://#diff-cef5f492916c2b2452181d018b9dfed3497621da5b668ee0890b0ebbd263758aL62-R64)

Test and platform consistency:

* Ensured that all test and platform-specific projects now reference package versions centrally, improving consistency and reducing the risk of version mismatches. [[1]](diffhunk://#diff-fb333c4f9938c1b7d80f9604b06f45e062c553e982ddc2fb91918a31b3bd1fc0L13-R13) [[2]](diffhunk://#diff-299fd45901d7653a2fc9975eb67935f7da4ae55d26002a1b10fbb46ef5c2013eL13-R15) [[3]](diffhunk://#diff-73374eaa0ac6a326c2f18dabe25885deec22e2246d80a5c4fb52549faf4558eeL41-R42) [[4]](diffhunk://#diff-50dbd169af612e7f52501516f3078caebd3b9d53ce3a32434e0ea7a11e9bd8e1L41-R41) [[5]](diffhunk://#diff-a77ee688d0bebc81cd42e8dff2b4bb63790c1594845f440dba4ea7f22a4b5b76L70-R70) [[6]](diffhunk://#diff-aecebcbbca575deff17eae605e96b1b8f11b7dde8fca4fda3b1d214ebc6b5219L73-R73) [[7]](diffhunk://#diff-8e88ea5a4f2a8819bb0b02d8bd7ea209a1120f8f9bab40bc179c1f09081ebba9L72-R73) [[8]](diffhunk://#diff-9fa1a52f4fa346f51dd8099c61312de2658f1251f7636c6577500b7aa06b1151L76-R78) [[9]](diffhunk://#diff-c616daa7c00f57965ffc8158d0b76ecdef3fe116f838c1cc28e5fedfbfe2ca3eL69-R70) [[10]](diffhunk://#diff-8484ca503c878a905da7dbc2f3ec8f12f1641d3026e47dd80d3398b74af673faL69-R70) [[11]](diffhunk://#diff-21a933b0d5f5c7e55743295e36505587e07cc6ff123bedd6d15d7f64c87409a9L69-R70) [[12]](diffhunk://#diff-bdfc0310b05ebac763fec7f37c2a01fc3868bc668448ca868ccc5d1b2e37ffddL75-R75) [[13]](diffhunk://#diff-c7eb80a1ade7e543d010ae2e5b30df425fa7fa27c21fb049ca03e5b98028f69dL55-R55) [[14]](diffhunk://#diff-04cd206d428bcc56f4106120e8ffce68e95ec577a06f2c918b1dd1429d46b4e1L63-R63) [[15]](diffhunk://#diff-67fcd2ea7c361a881b430859cb7c1ef9db2563522c2af68d38a51b10c2f52b33L64-R64) [[16]](diffhunk://#diff-847eb4777b9efa9363a1c9eb0b77bf2ee5f5c70cbb34281788896f15bbb491beL50-R50) [[17]](diffhunk://#diff-525ea9f6a7daa66d2ae31d94af88c9b313d77210c5ebdf0b835139637df4a308L62-R65) [[18]](diffhunk://#diff-cef5f492916c2b2452181d018b9dfed3497621da5b668ee0890b0ebbd263758aL62-R64)

No functional code changes were made; these updates strictly affect how dependencies are managed and referenced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized package version management across the solution, keeping dependency versions consistent in one place.
* **Refactor**
  * Replaced many project-level pinned package versions with shared version resolution.
  * Unified test, benchmark, and platform-specific dependency declarations to use the same version source.
* **Bug Fixes**
  * Reduced the chance of version drift between projects and build targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->